### PR TITLE
Fix crash because of uninitialized variable.

### DIFF
--- a/modules/missions/directions_mission.py
+++ b/modules/missions/directions_mission.py
@@ -64,13 +64,13 @@ class directions_mission (Director.Mission):
 
     def findUnit(self, name):
         i = VS.getUnitList()
-        un = i.current()
+        testun = i.current()
         while (not i.isDone()):
             if testun.getName().lower()==name.lower() or testun.getFullname().lower()==name.lower():
                 return testun
             testun = i.next()
         i = VS.getUnitList()
-        un = i.current()
+        testun = i.current()
         while (not i.isDone()):
             if testun.isDockableUnit():
                 return testun


### PR DESCRIPTION
When doing the first mission at the beginning of a new campaign, the game would crash on the final jump to Bernard's star. This was due to a misnamed variable in a python file. This commit fixes the issue.
