### PR TITLE
Removes the mis-aligned buttons in the nav console.

### DIFF
--- a/cockpits/nav/navdata.xml
+++ b/cockpits/nav/navdata.xml
@@ -4,6 +4,7 @@
 <Meshfile file="console.bfxm"    x_small=".12"  x_large=".7"  y_small=".15" y_large=".85" x_mesh_coord="-12.0" y_mesh_coord="0.0" z_mesh_coord="100.0" scale="1.4"/>
 </console>
 
+<!--
 <button1>
 <Meshfile file="b_generic.bfxm"   x=".755" y=".8"  dx=".11" dy=".05" x_mesh_coord="40.0" y_mesh_coord="42.0" z_mesh_coord="100.0" z_mesh_coord_delta="1.0" scale="1.4"/>
 </button1>
@@ -31,7 +32,7 @@
 <button7>
 <Meshfile file="b_generic.bfxm"   x=".755" y=".2" dx=".11" dy=".05" x_mesh_coord="40.0" y_mesh_coord="-30.0" z_mesh_coord="100.0" z_mesh_coord_delta="1.0" scale="1.4"/>
 </button7>
-
+-->
 <systemiteminfo>
 <Info itemscale="2.0" zshiftmultiplier="2.5" itemzscalefactor="2.0" unselectedalpha="0.4" minimumitemscaledown="0.3" maximumitemscaleup="6.0"/>
 </systemiteminfo>


### PR DESCRIPTION
Buttons are so last century.

It's only commented out in the file, so that we can make something prettier when we have the time.

The Nav computer needs an overhaul anyways. If I had a space ship that could jump to other galaxies,
and the nav computer installed in it was this basic I would give back that ship.

-------------------------------------------------------
I have a few ideas for improvements that should be fairly low-hanging. 

1. A search engine so you can map a route to any star that you have been to.
1.1 Route map to become an auto-generated mission?
2. "Fading" jump lines between solar systems depending on how far they are away from you to reduce on screen clutter
3. Un-fading mission routes to help with planning.


A screenshot of what the nav computer looks like without its buttons:
The horizontal line through is a glitch in my screen grabber util, it's not there in the game. 

<img width="1920" alt="Screenshot_20200711_103406" src="https://user-images.githubusercontent.com/12045269/87220748-f2742580-c366-11ea-8bfa-89cee32fd1e8.png">
