### PR TITLE
Adds in the missing colors for the nav computer in the config file

### DIFF
--- a/vegastrike.config
+++ b/vegastrike.config
@@ -381,7 +381,10 @@ Farther down, you will see "#GeomLow". Currently, it's line 213. You'll find mor
 
 <colors>
 	    <section name="nav">
-		<color name="destination_system"	r="0.0" g="0.0" b="0.0" a="0.0"/>
+                <color name="current_system"    r="1.0" g="0.3" b="0.3" a="1.0"/>
+                <color name="destination_system"        r="1.0" g="0.77" b="0.3" a="1.0"/>
+                <color name="slelection_system" r="0.3" g="1.0" b="0.3" a="1.0"/>
+                <color name="path_system"       r="1.0" g="1.0" b="1.0" a="1.0"/>
 	    </section>
 	    <section name="absolute">
 		<!-- absolute colors -->


### PR DESCRIPTION
This section was missing from the default config file. 
The colors are copies of the fallback colors in the source files, except for the path color. IMHO white works better in that case. 

In my test the paths were white, so the engine reads & respects the variables in the config file.