### PR TITLE
bases/main_menu.py: Bump version in intro title and credits title to 0.7

### DIFF
--- a/bases/main_menu.py
+++ b/bases/main_menu.py
@@ -48,7 +48,7 @@ def enterCredits(self,params):
     global plist_credits
     VS.musicPlayList(plist_credits)
 
-credits_title = """\t=== Vega Strike 0.5.2 alpha ===
+credits_title = """\t=== Vega Strike 0.7.0 ===
 \t        ---Credits---"""
 
 credits_text_col1 = """
@@ -154,7 +154,7 @@ User patience
 #CCCCff... and any we forgot to mention :)
 """
 
-intro_title = """\t=== Vega Strike 0.5.2 alpha ===
+intro_title = """\t=== Vega Strike 0.7.0 ===
 \t ---Intro Monologue---
 """
 


### PR DESCRIPTION
The 0.6.2 version of vsUTCS still says 0.5.2 alpha in these two places. Oops!

Updating master to reflect version 0.7.0. We may want to update the 0.6.x branch as well.