### PR TITLE
Migration: Artifacts for Release builds

### DIFF
--- a/.github/workflows/gh-actions-release.yml
+++ b/.github/workflows/gh-actions-release.yml
@@ -15,34 +15,48 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # only build one Deb File
+          # Source tarballs only
+          - FROM:     'ubuntu:focal'
+            COMPILER: 'clang'
+            FLAGS:    '-DUSE_PYTHON_3=ON'
+            ARTIFACT_EXT: 'tar.[xb]z*'
+          # only build one Deb File b/c they're so large
           #- FROM:     'ubuntu:focal'
           #  COMPILER: 'clang'
           #  FLAGS:    '-DUSE_PYTHON_3=ON'
+          #  ARTIFACT_EXT: 'deb'
           #- FROM:     'ubuntu:bionic'
           #  COMPILER: 'clang'
           #  FLAGS:    '-DUSE_PYTHON_3=ON'
+          #  ARTIFACT_EXT: 'deb'
           #- FROM:     'ubuntu:xenial'
           #  COMPILER: 'gcc'
           #  FLAGS:    '-DUSE_PYTHON_3=ON'
+          #  ARTIFACT_EXT: 'deb'
           #- FROM:     'debian:buster'
           #  COMPILER: 'clang'
           #  FLAGS:    '-DUSE_PYTHON_3=ON'
+          #  ARTIFACT_EXT: 'deb'
           - FROM:     'debian:stretch'
             COMPILER: 'gcc'
             FLAGS:    '-DUSE_PYTHON_3=ON'
+            ARTIFACT_EXT: 'deb'
           - FROM:     'opensuse/leap'
             COMPILER: 'clang'
             FLAGS:    '-DUSE_PYTHON_3=ON'
+            ARTIFACT_EXT: 'rpm'
           - FROM:     'fedora:33'
             COMPILER: 'clang'
             FLAGS:    '-DUSE_PYTHON_3=ON'
+            ARTIFACT_EXT: 'rpm'
           - FROM:     'fedora:32'
             COMPILER: 'clang'
             FLAGS:    '-DUSE_PYTHON_3=ON'
+            ARTIFACT_EXT: 'rpm'
           - FROM:     'centos:8'
             COMPILER: 'clang'
             FLAGS:    '-DUSE_PYTHON_3=ON'
+            ARTIFACT_EXT: 'rpm'
 
     steps:
     - name: Checkout repository
@@ -75,5 +89,6 @@ jobs:
       uses: skx/github-action-publish-binaries@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ARTIFACT_EXT: ${{ matrix.ARTIFACT_EXT }}
       with:
-        args: 'packages/Vega-Strike_v*.*'
+        args: "packages/*.${{ matrix.ARTIFACT_EXT }}"


### PR DESCRIPTION
Sync the github release workflow with what is done with the
Vega Strike engine so we build releases properly.

Thank you for submitting a pull request and becoming a contributor to Vega Strike: Upon the Coldest Sea.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only
- [x] CI Change only

Issues:
- #44 

Purpose:
- What is this pull request trying to do? Fix the releases for the source packaging; syncing with the VS Engine as we did the work there already so this mostly just a port.
- What release is this for? 0.7.x
- Is there a project or milestone we should apply this to? 0.7.x
