### PR TITLE
CMake do not require any compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
-PROJECT(vsUTCS)
+PROJECT(vsUTCS NONE)
 
 INSTALL(DIRECTORY .vegastrike/ DESTINATION share/vegastrike/.vegastrike
         PATTERN "*.am" EXCLUDE)


### PR DESCRIPTION
Set project language to NONE to disable CMake compiler check

There is nothing to compile here, so there is no need for a C and a C++ compiler.