### PR TITLE
Fix data entry error in attribute for starting weapon "Laser" - 0.8.x branch

### DIFF
--- a/weapon_list.xml
+++ b/weapon_list.xml
@@ -411,7 +411,7 @@
 <Bolt name="Laser" mountsize="light">  <!-- NOT ACTUALLY A LASER -->
 <Energy rate="4" stability="4" refire=".3">
 </Energy>
-<Damage damage="18" longrange=".4">
+<Damage rate="18" longrange=".4">
 </Damage>
 <Distance speed="2500" radialspeed="1" radius="1.2" length="10" pulsespeed="15" range="2880" >
 </Distance>


### PR DESCRIPTION
WAS: "damage"
NOW IS:"rate"
This should make the starting weapon have a well-defined damage value again

Thank you for submitting a pull request and becoming a contributor to Vega Strike: Upon the Coldest Sea.

Please answer the following:

Code Changes:
- [x] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- Please list any related issues
- Closes https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/479


Purpose:
- What is this pull request trying to do? Port #70 to 0.8.x
- What release is this for? 0.8.x
- Is there a project or milestone we should apply this to? 0.8.x
