### PR TITLE
Fedora 34 and Rocky Linux on 0.8.x

### DIFF
--- a/.github/workflows/gh-actions-pr.yml
+++ b/.github/workflows/gh-actions-pr.yml
@@ -42,9 +42,9 @@ jobs:
           - FROM:     'fedora:32'
             COMPILER: 'clang'
             FLAGS:    '-DUSE_PYTHON_3=ON'
-          - FROM:     'centos:8'
-            COMPILER: 'clang'
-            FLAGS:    '-DUSE_PYTHON_3=ON'
+          # - FROM:     'centos:8'
+          #   COMPILER: 'clang'
+          #   FLAGS:    '-DUSE_PYTHON_3=ON'
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/gh-actions-pr.yml
+++ b/.github/workflows/gh-actions-pr.yml
@@ -36,15 +36,18 @@ jobs:
           - FROM:     'opensuse/leap'
             COMPILER: 'clang'
             FLAGS:    '-DUSE_PYTHON_3=ON'
+          - FROM:     'fedora:34'
+            COMPILER: 'clang'
+            FLAGS:    '-DUSE_PYTHON_3=ON'
           - FROM:     'fedora:33'
             COMPILER: 'clang'
             FLAGS:    '-DUSE_PYTHON_3=ON'
           - FROM:     'fedora:32'
             COMPILER: 'clang'
             FLAGS:    '-DUSE_PYTHON_3=ON'
-          # - FROM:     'centos:8'
-          #   COMPILER: 'clang'
-          #   FLAGS:    '-DUSE_PYTHON_3=ON'
+          - FROM:     'rockylinux/rockylinux'
+            COMPILER: 'clang'
+            FLAGS:    '-DUSE_PYTHON_3=ON'
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/gh-actions-release.yml
+++ b/.github/workflows/gh-actions-release.yml
@@ -29,6 +29,10 @@ jobs:
             COMPILER: 'clang'
             FLAGS:    '-DUSE_PYTHON_3=ON'
             ARTIFACT_EXT: 'rpm'
+          - FROM:     'fedora:34'
+            COMPILER: 'clang'
+            FLAGS:    '-DUSE_PYTHON_3=ON'
+            ARTIFACT_EXT: 'rpm'
           - FROM:     'fedora:33'
             COMPILER: 'clang'
             FLAGS:    '-DUSE_PYTHON_3=ON'
@@ -37,10 +41,10 @@ jobs:
             COMPILER: 'clang'
             FLAGS:    '-DUSE_PYTHON_3=ON'
             ARTIFACT_EXT: 'rpm'
-          # - FROM:     'centos:8'
-          #   COMPILER: 'clang'
-          #   FLAGS:    '-DUSE_PYTHON_3=ON'
-          #   ARTIFACT_EXT: 'rpm'
+          - FROM:     'rockylinux/rockylinux'
+            COMPILER: 'clang'
+            FLAGS:    '-DUSE_PYTHON_3=ON'
+            ARTIFACT_EXT: 'rpm'
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/gh-actions-release.yml
+++ b/.github/workflows/gh-actions-release.yml
@@ -37,10 +37,10 @@ jobs:
             COMPILER: 'clang'
             FLAGS:    '-DUSE_PYTHON_3=ON'
             ARTIFACT_EXT: 'rpm'
-          - FROM:     'centos:8'
-            COMPILER: 'clang'
-            FLAGS:    '-DUSE_PYTHON_3=ON'
-            ARTIFACT_EXT: 'rpm'
+          # - FROM:     'centos:8'
+          #   COMPILER: 'clang'
+          #   FLAGS:    '-DUSE_PYTHON_3=ON'
+          #   ARTIFACT_EXT: 'rpm'
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to Vega Strike: Upon the Coldest Sea.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only
- [X] This is a CI/build system change only

Issues:
- Please list any related issues

Purpose:
- What is this pull request trying to do? Update the set of supported Linux distributions: replace CentOS 8 with Rocky Linux 8.4, and add Fedora 34
- What release is this for? 0.8.x
- Is there a project or milestone we should apply this to? 0.8.x
