### PR TITLE
Integer division fixed for py3

### DIFF
--- a/modules/GUI.py
+++ b/modules/GUI.py
@@ -1656,7 +1656,7 @@ class GUISimpleListPicker(GUIElement):
         self._recheck()
 
     def viewMove(self,lines):
-        self.firstVisible = max(0,min(len(self.items)-1-len(self._listitems)/2,self.firstVisible + lines))
+        self.firstVisible = max(0,min(len(self.items)-1-len(self._listitems)//2,self.firstVisible + lines))
         self.notifyNeedRedraw()
         self._recheck()
 


### PR DESCRIPTION
Integer division fixed for py3 in GUISimpleListPicker.viewMove, it caused a bug scrolling after the last text page in the Introduction. (py2: 4 / 5 -> 0; py3: 4 / 5 -> 0.8)

Thank you for submitting a pull request and becoming a contributor to Vega Strike: Upon the Coldest Sea.

Please answer the following:

Code Changes:
- [x] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- Please list any related issues
https://github.com/vegastrike/Assets-Masters/issues/30

Purpose:
- What is this pull request trying to do?
    Fixing the Intro Monologue crash
- What release is this for?
    0.8.x
- Is there a project or milestone we should apply this to?
    0.8.x
