### PR TITLE
Fix AddCargo for py3

### DIFF
--- a/modules/campaign_lib.py
+++ b/modules/campaign_lib.py
@@ -358,7 +358,7 @@ class AddCargo(Script):
             debug.debug("Successfully added "+str(numsofar))
             numadded=0
             if (numsofar<self.cargnum):
-                for i in range(you.numCargo(), 0, -1):
+                for i in range(you.numCargo() - 1, -1, -1):
                     karg=you.GetCargoIndex(i)
                     if (not karg.GetMissionFlag()):
                         if (karg.GetCategory().find("upgrades")==-1):

--- a/modules/campaign_lib.py
+++ b/modules/campaign_lib.py
@@ -358,7 +358,7 @@ class AddCargo(Script):
             debug.debug("Successfully added "+str(numsofar))
             numadded=0
             if (numsofar<self.cargnum):
-                rang=list[list(range(you.numCargo()))]
+                rang=list(range(you.numCargo()))
                 rang.reverse()
                 for i in rang:
                     karg=you.GetCargoIndex(i)

--- a/modules/campaign_lib.py
+++ b/modules/campaign_lib.py
@@ -358,9 +358,7 @@ class AddCargo(Script):
             debug.debug("Successfully added "+str(numsofar))
             numadded=0
             if (numsofar<self.cargnum):
-                rang=list(range(you.numCargo()))
-                rang.reverse()
-                for i in rang:
+                for i in range(you.numCargo(), 0, -1):
                     karg=you.GetCargoIndex(i)
                     if (not karg.GetMissionFlag()):
                         if (karg.GetCategory().find("upgrades")==-1):


### PR DESCRIPTION
Cargo missions in campaigns (e.g. Jenek's) give an error when the cargo is loaded on the ship but there's not enough space for it.
@stephengtuggy reported it in the issue below, and the error is
`TypeError: 'type' object is not subscriptable` cause by the line
```
rang=list[list(range(you.numCargo()))]
```

On my Linux system with Python 3.9.7 the error is different
`TypeError: unbound method list.reverse() needs an argument`
and it happens on the next line
```
rang.reverse()
```

Due to this difference in behavior, pre-emptive test of this fix on all platforms is a must.


Thank you for submitting a pull request and becoming a contributor to Vega Strike: Upon the Coldest Sea.

Please answer the following:

Code Changes:
- [x] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- Please list any related issues
 https://github.com/vegastrike/Assets-Masters/issues/32

Purpose:
- What is this pull request trying to do?
 Fix the error, allowing the original behavior: some cargo gets sold automatically to make room for the mission cargo.
- What release is this for?
 0.8.x
- Is there a project or milestone we should apply this to?
 0.8.x
