### PR TITLE
Change Fortify On-Demand Scan to run only when manually triggered (0.8.x)

### DIFF
--- a/.github/workflows/fortify-on-demand-scan.yml
+++ b/.github/workflows/fortify-on-demand-scan.yml
@@ -1,11 +1,9 @@
 name: Fortify on Demand Scan
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
-  push:
-    # branches: ['master', '[0-9]?.[0-9]?.x']
-  pull_request:
-    # branches: ['master', '[0-9]?.[0-9]?.x']
+#   push:
+#   pull_request:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to Vega Strike: Upon the Coldest Sea.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only
- [X] This is a CI system change only

Issues:
- Please list any related issues
- N/A

Purpose:
- What is this pull request trying to do? Disable the Fortify On-Demand Scan workflow from running except when manually triggered, as discussed. This is the 0.8.x equivalent of #78 
- What release is this for? 0.8.x
- Is there a project or milestone we should apply this to? 0.8.x
