### PR TITLE
Enhancement: Display Engine Version Information

### DIFF
--- a/modules/GUI.py
+++ b/modules/GUI.py
@@ -354,6 +354,32 @@ class GUIRoot:
         self.needRedraw = {}
         self.modalElement = None
         self.keyTarget = None
+
+        hasVersion = hasattr(VS, 'EngineVersion')
+        # get the engine version tuple in a displayable format
+        # if it needs to be compared, then use the original tuple version
+        ev = (
+            VS.EngineVersion().GetVersion()
+            if hasVersion
+            else (0, 7, 0, 'unknown') # 0.7.x was the last version without this API
+        )
+        engineVersion = '.'.join(
+            [
+                str(i)
+                for i in ev
+            ]
+        )
+
+        apiVersion = (
+            VS.EngineVersion().GetAssetAPIVersion()
+            if hasVersion
+            else 0
+        )
+
+        trace(TRACE_WARNING, "::: What's in VS object %s :::" %(dir(VS)))
+        trace(TRACE_WARNING, "::: Engine Version {0} :::".format(engineVersion))
+        trace(TRACE_WARNING, "::: Asset API Version {0} :::".format(apiVersion))
+
         Base.GlobalKeyPython('#\nfrom GUI import GUIRootSingleton\nGUIRootSingleton.keyEvent()\n')
 
     def setScreenDimensions(self,screenX,screenY):


### PR DESCRIPTION
Output the Engine Version and the Engine API Version for diagnostics.
A future PR can take are of checking for a minimum version, which
should be done against the Engine API Version.

Thank you for submitting a pull request and becoming a contributor to Vega Strike: Upon the Coldest Sea.

Please answer the following:

Code Changes:
- [x] Have the PR Validation Tests been run? As relevant
- [ ] This is a documentation change only

Issues:
- #80 

Purpose:
Port #80 to the 0.8.x branch.