### PR TITLE
Add Fedora 36 and Manjaro Linux

### DIFF
--- a/.github/workflows/gh-actions-pr.yml
+++ b/.github/workflows/gh-actions-pr.yml
@@ -14,9 +14,11 @@ jobs:
           # only do one Deb file because they're so large
           - FROM:     'debian:buster'
           - FROM:     'opensuse/leap'
+          - FROM:     'fedora:36'
           - FROM:     'fedora:35'
           - FROM:     'fedora:34'
           - FROM:     'rockylinux/rockylinux'
+          - FROM:     'manjarolinux/base'
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/gh-actions-release.yml
+++ b/.github/workflows/gh-actions-release.yml
@@ -23,6 +23,8 @@ jobs:
             ARTIFACT_EXT: 'deb'
           - FROM:     'opensuse/leap'
             ARTIFACT_EXT: 'rpm'
+          - FROM:     'fedora:36'
+            ARTIFACT_EXT: 'rpm'
           - FROM:     'fedora:35'
             ARTIFACT_EXT: 'rpm'
           - FROM:     'fedora:34'


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to Vega Strike: Upon the Coldest Sea.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only
- [X] This is a CI/CD build system change only (and I have tested the code itself extensively on Manjaro)

Issues:
- Please list any related issues

Purpose:
- What is this pull request trying to do? Add Fedora 36 and Manjaro Linux into the CI/CD pipeline for vsUTCS
- What release is this for? 0.9.x
- Is there a project or milestone we should apply this to? 0.9.x
