### PR TITLE
Add Fedora 36 and Manjaro Linux support to 0.8.x

### DIFF
--- a/.github/workflows/gh-actions-pr.yml
+++ b/.github/workflows/gh-actions-pr.yml
@@ -14,9 +14,11 @@ jobs:
           # only do one Deb file because they're so large
           - FROM:     'debian:buster'
           - FROM:     'opensuse/leap'
+          - FROM:     'fedora:36'
           - FROM:     'fedora:35'
           - FROM:     'fedora:34'
           - FROM:     'rockylinux/rockylinux'
+          - FROM:     'manjarolinux/base'
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/gh-actions-release.yml
+++ b/.github/workflows/gh-actions-release.yml
@@ -23,6 +23,8 @@ jobs:
             ARTIFACT_EXT: 'deb'
           - FROM:     'opensuse/leap'
             ARTIFACT_EXT: 'rpm'
+          - FROM:     'fedora:36'
+            ARTIFACT_EXT: 'rpm'
           - FROM:     'fedora:35'
             ARTIFACT_EXT: 'rpm'
           - FROM:     'fedora:34'


### PR DESCRIPTION
(cherry picked from commit d8de81469134f23d13d606da89b9cf9f998d50a5)

Thank you for submitting a pull request and becoming a contributor to Vega Strike: Upon the Coldest Sea.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only
- [ ] This is a CI/CD/build system change only

Issues:
- Please list any related issues

Purpose:
- What is this pull request trying to do? Add Fedora 36 and Manjaro Linux to CI/CD for VS:UtCS 0.8.x
- What release is this for? 0.8.x
- Is there a project or milestone we should apply this to? Not sure which
