### PR TITLE
mac.fp: `texture2DLod` => `textureLod`

### DIFF
--- a/programs/mac.fp
+++ b/programs/mac.fp
@@ -41,7 +41,7 @@ float shininess2Lod(float shininess) { return max(0.0,7.0-log2(shininess+1.0))+3
 vec3 envMapping(in vec3 reflection, in float shininess, in vec4 specmap)
 {
    float envLod = shininess2Lod(shininessMap(shininess,specmap));
-   return texture2DLod(envMap, EnvMapGen(reflection), envLod).rgb * specmap.rgb * envColor.rgb;
+   return textureLod(envMap, EnvMapGen(reflection), envLod).rgb * specmap.rgb * envColor.rgb;
 }
 
 


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to Vega Strike: Upon the Coldest Sea.

Please answer the following:

Code Changes:
- [Partly] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation

Issues:
- Please list any related issues

Purpose:
- What is this pull request trying to do? It seems that `texture2DLod` and similar [are deprecated](https://community.khronos.org/t/texture2dlod-deprecated/60894) in modern GLSL. This was causing errors to show up in the logs on my Mac. This PR fixes that.
- What release is this for? 0.9.x, probably
- Is there a project or milestone we should apply this to? 0.9.x, probably
