### PR TITLE
Migrate from imp to importlib

### DIFF
--- a/modules/custom.py
+++ b/modules/custom.py
@@ -1,7 +1,7 @@
 import VS
 import traceback
 import sys
-import imp
+import importlib
 
 procedures = {
         }
@@ -124,7 +124,7 @@ def processMessage(local, cmd, argstr, id):
         for arg in args:
             print(arg)
         if cmd=='reloadlib' and local and len(args)>=1:
-            imp.reload(__import__(args[0]))
+            importlib.reload(__import__(args[0]))
             VS.IOmessage(0, "game", "p"+str(cp), "Reloaded "+str(args[0]))
         elif cmd=='local':
             # simple way of bouncing back message to client....

--- a/modules/dj.py
+++ b/modules/dj.py
@@ -1,4 +1,4 @@
 import dj_lib
-import imp
-imp.reload(dj_lib)
+import importlib
+importlib.reload(dj_lib)
 dj_lib.PlayMusik()

--- a/modules/server.py
+++ b/modules/server.py
@@ -3,7 +3,7 @@ import Director
 import unit
 import sys
 import traceback
-import imp
+import importlib
 import custom
 
 import server_lib
@@ -176,7 +176,7 @@ def processMessage(cp, localhost, command, arglist=None, id=''):
             if authlevel<1:
                 return
             mod=server_lib
-            imp.reload(mod)
+            importlib.reload(mod)
             VS.IOmessage(0,"game","all","The server python script has been reloaded!")
             print(mod.__name__+' has been reloaded!')
         else:

--- a/modules/server_lib.py
+++ b/modules/server_lib.py
@@ -10,7 +10,7 @@ import universe
 import faction_ships
 import custom
 import campaign_lib
-import imp
+import importlib
 
 def serverDirector():
     return server.getDirector()
@@ -142,7 +142,7 @@ def processMessage(player, auth, command, args, id=''):
         if auth<1:
             return
         vsmod=VS
-        imp.reload(__import__('server_lib'))
+        importlib.reload(__import__('server_lib'))
         vsmod.IOmessage(0,"game","all","The server python script has been reloaded.")
     elif command=='userlist':
         cstr = '#44cc44Users on the server:#888800'


### PR DESCRIPTION
- the 'imp' module is deprecated from years and now Python 3.12 finally drops completely support of 'imp' module.
- fix for #107
