### PR TITLE
Add missing config.json to support #892

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,7 @@ INSTALL(FILES weapons.json DESTINATION share/vegastrike)
 # Linux specific locations from here on out.
 
 INSTALL(FILES vegastrike.config DESTINATION share/vegastrike)
+INSTALL(FILES config.json DESTINATION share/vegastrike)
 
 INSTALL(FILES vegastrike.desktop DESTINATION share/applications)
 INSTALL(FILES vegasettings.desktop DESTINATION share/applications)

--- a/config.json
+++ b/config.json
@@ -1,0 +1,10 @@
+{
+"general": {},
+
+"graphics": {
+    "resolution_x": 2560,
+    "resolution_y": 1600,
+    "screen": 0
+},
+"advanced": {}
+}


### PR DESCRIPTION
This is the complementing config.json for [#892](https://github.com/vegastrike/Vega-Strike-Engine-Source/pull/892).

Please answer the following:

Code Changes:
- [x] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation


Issues:
- This temporarily deprecates the settings app.


