### PR TITLE
Windows-Release.yml: invoke CPack via CMake:… (0.10.x)

### DIFF
--- a/.github/workflows/Windows-Release.yml
+++ b/.github/workflows/Windows-Release.yml
@@ -56,7 +56,7 @@ jobs:
         run: script/build
 
       - name: Package it
-        run: cpack -V -G NSIS
+        run: cmake --build . --target package
 
       - name: Upload the artifacts
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1


### PR DESCRIPTION
… `cmake --build . --target package`

Code Changes:
- [X] This is a CI/build system change only (and I have run the cmake command locally to make sure that it works)

Issues:
- N/A

Purpose:
- What is this pull request trying to do? Fix the Windows packaging of the vsUTCS Assets, for 0.10.x and following
- What release is this for? 0.10.x
- Is there a project or milestone we should apply this to? 0.10.x
