### PR TITLE
Remove useless function `ShowProgress.setProgressBar()`

### DIFF
--- a/modules/ShowProgress.py
+++ b/modules/ShowProgress.py
@@ -53,8 +53,3 @@ def setProgressMessage(screen_id,message):
         if prefix != "":
             prefix += ": "
         VS.showSplashMessage(prefix+message)
-
-def setProgressBar(screen_id,progress):
-    global __showing
-    if screen_id == __showing:
-        VS.showSplashProgress(progress)

--- a/modules/fg_util.py
+++ b/modules/fg_util.py
@@ -397,7 +397,6 @@ def DeleteLegacyFGLeftovers():
         count += 1
         pct = count*100/len(allsys)
         if pct != oldpct:
-            ShowProgress.setProgressBar("loading",pct/100.)
             ShowProgress.setProgressMessage("loading","Resetting old universe (%d%%)" % (pct))
             oldpct = pct
         DeleteLegacyFGs(sys)

--- a/modules/generate_dyn_universe.py
+++ b/modules/generate_dyn_universe.py
@@ -154,7 +154,6 @@ def AddSysDict (cursys):
     #debug.debug("Initializing system %s with %d flightgroups... " % (cursys,numflightgroups))
     progress_percent = (_generatedsys / getSystemCount())
     if progress_percent - _last_progress_percent > 0.01:
-        ShowProgress.setProgressBar("loading",progress_percent)
         ShowProgress.setProgressMessage("loading","Generating dynamic universe (%.2f%%)" % (100*progress_percent))
         _last_progress_percent = progress_percent
     _generatedsys += 1


### PR DESCRIPTION
The C++ engine does not do anything with it.
See: https://github.com/vegastrike/Vega-Strike-Engine-Source/blob/3517e33b96b4ce9e0214c736d7379aa8a2b39d79/engine/src/universe_util.cpp#L204

When/if this is merged, I have the part removing the (then also unused) C++ code.

Code Changes:
- [X] Have the PR Validation Tests been run? compiled engine and run with this PR, on linux/musl
- [ ] This is a documentation change only

Issues:
- Not sure if this should go to Assets Master, even if I've read [the issue 14](https://github.com/vegastrike/Assets-Masters/issues/14) and [the issue 4](https://github.com/vegastrike/Assets-Production/issues/4). As I've done that here for testing purpose, I created the PR here. I'll move upon request / clarification.

Purpose:
- What is this pull request trying to do? Remove unused code
- What release is this for? Next
- Is there a project or milestone we should apply this to? Next
