### PR TITLE
Fix travel mode multiplier

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,8 +2,8 @@
 "general": {},
 
 "graphics": {
-    "resolution_x": 2560,
-    "resolution_y": 1600,
+    "resolution_x": 1920,
+    "resolution_y": 1080,
     "screen": 0
 },
   

--- a/config.json
+++ b/config.json
@@ -6,40 +6,40 @@
     "resolution_y": 1080,
     "screen": 0
 },
-  
+
 "components": {
     "afterburner": {
     },
-        
+
     "drive": {
         "non_combat_mode_multiplier": 1000
     },
-    
+
     "energy": {
         "factor": 1
     },
-    
+
     "fuel": {
         "fuel_equals_warp": false,
         "factor": 600
     },
-    
+
     "ftl_drive": {
         "factor": 0.1
     },
-    
+
     "ftl_energy": {
         "factor": 1.0
     },
-    
+
     "jump_drive": {
         "factor": 1.0
     },
-    
+
     "reactor": {
         "factor": 1.0
     }
-    
+
 },
 
 "constants": {
@@ -53,6 +53,6 @@
     "introduction": 
         "Welcome to Vega Strike!\nUse #8080FFTab#000000 to afterburn (#8080FF+,-#000000 cruise control),\n#8080FFarrows#000000 to steer.\nThe #8080FFt#000000 key targets objects; #8080FFspace#000000 fires at them & #8080FFa#000000 activates the SPEC drive.\nTo go to another star system, buy a jump drive for about 10000 credits,\nfly to a wireframe jump-point and press #8080FFj#000000 to warp to a near star.\nTarget a base or planet;\nWhen you get close a green box will appear. Inside the box, #8080FFd#000000 will land."    
 },
-  
+
 "advanced": {}
 }

--- a/config.json
+++ b/config.json
@@ -12,7 +12,7 @@
     },
         
     "drive": {
-        "non_combat_mode_multiplier": 100
+        "non_combat_mode_multiplier": 1000
     },
     
     "energy": {

--- a/config.json
+++ b/config.json
@@ -2,8 +2,8 @@
 "general": {},
 
 "graphics": {
-    "resolution_x": 1920,
-    "resolution_y": 1080,
+    "resolution_x": 2560,
+    "resolution_y": 1600,
     "screen": 0
 },
 

--- a/units/units.json
+++ b/units/units.json
@@ -582,6 +582,7 @@
     {
         "Key": "add_spec_capacitor02__upgrades",
         "Name": "FTL Energy Capacitor II",
+        "Upgrade_Type": "FTL_Capacitor",
         "Object_Type": "Upgrade_Additive",
         "Textual_Description": "Capacitor for storing energy for FTL travel",
         "Mass": "1",


### PR DESCRIPTION
Code Changes:
- [x] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation

Issues Addressed:
- Addresses https://github.com/vegastrike/Assets-Masters/issues/63

Known Issues Remaining:
- The travel mode multiplier isn't fixed. Still stuck at 100x most of the time. More troubleshooting is needed.

Purpose:
- What is this pull request trying to do? Fix https://github.com/vegastrike/Assets-Masters/issues/63 
- What release is this for? 0.10.x
- Is there a project or milestone we should apply this to? 0.10.x
