### PR TITLE
Fix vsUTCS Start Menu Item for 0.9.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,10 +213,10 @@ IF (CMAKE_SYSTEM_NAME STREQUAL Windows)
     SET(CPACK_NSIS_CONTACT "maintainers@vega-strike.org")
     SET(CPACK_NSIS_MODIFY_PATH OFF)
     SET(CPACK_NSIS_CREATE_ICONS_EXTRA
-        "CreateShortCut '$SMPROGRAMS/$STARTMENU_FOLDER/Vega Strike Upon the Coldest Sea.lnk' 'C:/Program Files/VegaStrike-0.9/bin/vegastrike-engine.exe' -D\"$INSTDIR\\share\\vegastrike\""
+        "CreateShortCut '$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\Vega Strike Upon the Coldest Sea.lnk' 'C:\\\\Program Files\\\\VegaStrike-0.9\\\\bin\\\\vegastrike-engine.exe' -D\"$INSTDIR\\share\\vegastrike\""
     )
     SET(CPACK_NSIS_DELETE_ICONS_EXTRA
-        "Delete '$SMPROGRAMS/$START_MENU/Vega Strike Upon the Coldest Sea.lnk'"
+        "Delete '$SMPROGRAMS\\\\$START_MENU\\\\Vega Strike Upon the Coldest Sea.lnk'"
     )
     SET(CPACK_GENERATOR "NSIS64")
     SET(CPACK_PACKAGE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/packages")


### PR DESCRIPTION
Code Changes:
- [X] This is an installer change only, and can't be tested very well until a new installer is built.

Issues Addressed:
- Fixes https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/1130 (hopefully)

Known Issues Remaining:
- No new ones that I'm aware of

Purpose:
- What is this pull request trying to do? Fix the set of Vega Strike menu item(s) installed by the installers
- What release is this for? 0.9.1
- Is there a project or milestone we should apply this to? 0.9.x
