### PR TITLE
CMakeLists.txt: Fix vsUTCS Start Menu item for 0.10.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,7 +233,13 @@ IF (CMAKE_SYSTEM_NAME STREQUAL Windows)
     SET(CPACK_NSIS_HELP_LINK "https://vega-strike.org")
     SET(CPACK_NSIS_URL_INFO_ABOUT "https://vega-strike.org/about")
     SET(CPACK_NSIS_CONTACT "maintainers@vega-strike.org")
-    SET(CPACK_NSIS_MODIFY_PATH ON)
+    SET(CPACK_NSIS_MODIFY_PATH OFF)
+    SET(CPACK_NSIS_CREATE_ICONS_EXTRA
+        "CreateShortCut '$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\Vega Strike Upon the Coldest Sea.lnk' 'C:\\\\Program Files\\\\VegaStrike-0.10\\\\bin\\\\vegastrike-engine.exe' -D\"$INSTDIR\\share\\vegastrike\""
+    )
+    SET(CPACK_NSIS_DELETE_ICONS_EXTRA
+        "Delete '$SMPROGRAMS\\\\$START_MENU\\\\Vega Strike Upon the Coldest Sea.lnk'"
+    )
 
     SET(CPACK_GENERATOR "NSIS64")
     SET(CPACK_PACKAGE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/packages")


### PR DESCRIPTION
Code Changes:
- [x] This is an installer / build system change only, and can't be tested very well until a new installer is built

Issues Addressed:
- N/A

Known Issues Remaining:
- Folder customization options are limited, at least if you want the game shortcut to work

Purpose:
- What is this pull request trying to do? Fix the Start Menu shortcut for Vega Strike Upon the Coldest Sea 0.10.x
- What release is this for? 0.10.x
- Is there a project or milestone we should apply this to? 0.10.x
