### PR TITLE
Add optional attributes to cargo: passenger, slave, upgrade, weapon

### DIFF
--- a/cargo_modify.py
+++ b/cargo_modify.py
@@ -13,7 +13,7 @@ def modify_item(item):
         item["upgrade"] = True
 
     if item.get("categoryname").startswith("upgrades/Weapons") or item.get("categoryname").startswith("upgrades/Ammunition"):
-        item["weapoon"] = True
+        item["weapon"] = True
 
 
 if __name__ == '__main__':

--- a/cargo_modify.py
+++ b/cargo_modify.py
@@ -1,0 +1,37 @@
+import json
+
+
+def modify_item(item):
+    if item.get("categoryname").startswith("Passengers"):
+        item["passenger"] = True
+
+    if "Slaves" == item.get("file") or "Pilot" == item.get("file"):
+        item["passenger"] = True
+        item["slave"] = True
+    
+    if item.get("categoryname").startswith("upgrades/"):
+        item["upgrade"] = True
+
+    if item.get("categoryname").startswith("upgrades/Weapons") or item.get("categoryname").startswith("upgrades/Ammunition"):
+        item["weapoon"] = True
+
+
+if __name__ == '__main__':
+    items = []
+    upgrades = []
+    weapons = []
+
+    jsons = ['master_component_list.json', 'master_part_list.json', 'master_ship_list.json']
+    
+    for json_file in jsons:
+        with open(json_file,'r') as items_file:
+            items_str = items_file.read()
+            items = json.loads(items_str)
+
+        for item in items:
+            modify_item(item)
+
+        with open(json_file, 'w') as units_file:
+            json.dump(items, units_file, ensure_ascii=False, indent=4)
+      
+    print("Success")

--- a/master_component_list.json
+++ b/master_component_list.json
@@ -223,7 +223,8 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@The logical conclusion of decades of upscaling work with spatial disruption technology, this weapon finds its home only among the weapons mounted on the capital vessels of well funded space navies.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "flak",
@@ -233,7 +234,8 @@
         "volume": "1",
         "description": "@upgrades/beam2.image@Like fireworks - only full of razorblades.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "flak_heavy",
@@ -243,7 +245,8 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@There, there Snowden.... there, there.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "lr_disruptor_beam",
@@ -253,7 +256,8 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@A variant of the Disruptor Beam, this weapon uses the same functional principals, but is engineered for use at long range. Projecting something that is, in many respects, an extremely long sliver of a shield poses a number of technical difficulties. Long range disruptor beams increase the effective range of the weapon, but at the cost of dramatic reductions to efficiency, damage output, and beam stability alongside a significantly increased physical size. However, for certain applications, such as point-defense emplacements, these trade-offs have been considered more than worthwhile.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Relativistic_Particle_Beam",
@@ -263,7 +267,8 @@
         "volume": "1",
         "description": "@upgrades/medium.image@While slinging particles of negligible mass, and in chaste quantities, this weapon does manage to propel them at significant fractions of lightspeed, rendering the particles quite dangerous to encounter.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "photon_capship",
@@ -273,7 +278,8 @@
         "volume": "1",
         "description": "@upgrades/heavy.image@The standard armament of most heavy Aeran vessels, this is a scaled up version of the same PESC type warhead delivery system used in Aeran combat craft.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "rlr_laser_beam",
@@ -283,7 +289,8 @@
         "volume": "1",
         "description": "@upgrades/medium.image@A long ranged laser weapon used primarily in Aeran point defence emplacements.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "FS_MWRF_Laser",
@@ -293,7 +300,8 @@
         "volume": "1",
         "description": "@upgrades/medium.image@Rapid-fire microwave laser: When an enemy vessel has had enough it will go 'ding'. Or, possibly, explode.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "FS_MW_Laser",
@@ -303,7 +311,8 @@
         "volume": "1",
         "description": "@upgrades/heavy.image@Microwave laser: Caution -- do not stand in front of laser when attempting to defrost chickens.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "FS_IRRF_Laser",
@@ -313,7 +322,8 @@
         "volume": "1",
         "description": "@upgrades/heavy.image@Rapid-fire infrared laser: Even on the coldest sea, it can still be Hot, Hot, Hot!",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "FS_IR_Laser",
@@ -323,7 +333,8 @@
         "volume": "1",
         "description": "@upgrades/heavy.image@Infrared laser: When using for grilling, please refrain from putting hands, feet, or population centers in front of the lasing surface.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Jackhammer",
@@ -333,7 +344,8 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@The Jackhammer is an open-cycle laser, venting its coolant after every firing sequence. While this does wonders for the size and complexity of the cooling system, it does raise ammunition capacity issues not frequently associated with modern lasers.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Jackhammer_ammo",
@@ -343,7 +355,8 @@
         "volume": "1",
         "description": "@cargo/halogen_gasses.image@Coolant for the open-cycle Jackhammer laser.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "CS_UVRF_Laser",
@@ -353,7 +366,8 @@
         "volume": "1",
         "description": "@upgrades/turret_heavy.image@Rapid-fire UV Laser. UV and other higher frequency lasers raise increasing concerns about cooling. Fortunately, UV and higher frequency lasers are effective enough to warrant being built into capital sized mounts that can handle their cooling requirements.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "CS_UV_Laser",
@@ -363,7 +377,8 @@
         "volume": "1",
         "description": "@upgrades/turret_heavy.image@UV Laser. Unlike most exposures to UV light, taking in these rays decreases the risk of dying from skin cancer.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "CS_XRRF_Laser",
@@ -373,7 +388,8 @@
         "volume": "1",
         "description": "@upgrades/turret_heavy.image@Rapid-fire Xaser. Used properly, one can use a Xaser to figure out what the inside of an enemy vessel looks like. The crew, however, tends to cease to have insides at about the same time.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "CS_XR_Laser",
@@ -383,7 +399,8 @@
         "volume": "1",
         "description": "@upgrades/turret_heavy.image@Xaser. The X-ray spectrum and lasers are notoriously unfriendly to being combined. That xasers exist at all just goes to show that some relationships can be made to work if there's enough money in it for everyone else involved.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Particle_Beam",
@@ -393,7 +410,8 @@
         "volume": "1",
         "description": "@upgrades/medium.image@It has long been known that lightweight, charged particles, while easy to accelerate, suffer greatly from electro-static bloom effects. However, it has also long been known that there's not much in the universe cheaper to obtain than lightweight, charged particles. Still, it's not your great-to-the-Nth-granddaddy's cathode ray tube. (It's a lot bigger than that).",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Ion_Beam",
@@ -403,7 +421,8 @@
         "volume": "1",
         "description": "@upgrades/medium.image@Adding a bit more heft to the input stream than what is found in weapons termed particle beams, this weapon nonetheless operates on the same general principles. The electric charge of ionized plasma makes it particularly easy to compress and fire using simple magnetics. Deceptively simple in design, these weapons' cost comes from the inherent difficulty in making a stream of ionized plasma remain coherent _after_ firing. In the last ten years, advances in this field have led to noted increases in the accessibility of ion beam weapons, and to a market glut of cheap knockoff brands.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Heavy_Ion_Beam",
@@ -413,7 +432,8 @@
         "volume": "1",
         "description": "@upgrades/heavy.image@A variant of the somewhat more common Ion Beam, these weapons utilizes heavier ions, such as xenon. Heavier ions are more difficult to accelerate to the desired exit velocities, but do not suffer nearly as much from electro-static bloom effects as their lighter counterparts.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Ion_Burster",
@@ -423,7 +443,8 @@
         "volume": "1",
         "description": "@upgrades/beam2.image@One of the smallest of the ion weapon family, the Ion Burster, despite a seemingly projectile output, is more closely related to ion beam weapons than to anything else. Indeed, the lower speed and packetized nature of the weapon's output are not so much desirable attributes as concessions: in order to make the weapon small enough to meet design specifications, the beam can only be pulsed, and infrequently at that. To compensate for this disability, the Ion Burster relies on specially prepared vaporization plates, rather than the homogeneous gas-streams ususally feeding Ion weapons.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Ion_Burster_ammo",
@@ -433,7 +454,8 @@
         "volume": "1",
         "description": "@cargo/halogen_gasses.image@Prepackaged vaporization plates for the Ion Burster gun.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Disruptor_Beam",
@@ -443,7 +465,8 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@The canonical example of shield-based weaponry, the disruptor beam is highly effective at disrupting the twisted maze of forces created by a shield generator, but entirely unequipped to trickle damage past a shield until the shield in question has already nearly faltered. Disruptors, just like the shields they share most of their technological lineage with, interact violently with matter, making them poorly suited to use outside of vacuum. Fortunately for those on the receiving end of a disruptor blast, even a shield de-patterned to the point of collapse will mitigate a disruptor's effects on materials beyond the shield. Unfortunately for those on the receiving end of a disruptor, mitigate is not the same as eliminate. Those unfortunate enough to receive disruptor fire with no shield generator at all are usually at least fortunate enough that the shear forces kill them before they can notice. This design is exceptionally popular among adherents to the trekkie religion, but its reliability and effectiveness make it nothing to scoff at.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Shield_Breaker",
@@ -453,7 +476,8 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@This Highborn Milspec weapon was designed alongside the Lancelot superiority fighter. If nearly equivalent in fundamental design principles, its implementation and engineering is superior in nearly every respect to the Disruptor Beams it shares a common origin with. In keeping with the naming of the ship it was co-designed with, the Shield Breaker is well suited to render any shield within reach quite humbled in but a small number of lancing blows.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "LR_Disruptor_Beam",
@@ -463,7 +487,8 @@
         "volume": "1",
         "description": "@upgrades/heavy.image@A variant of the Disruptor Beam, this weapon uses the same functional principals, but is engineered for use at long range. Projecting something that is, in many respects, an extremely long sliver of a shield poses a number of technical difficulties. Long range disruptor beams increase the effective range of the weapon, but at the cost of dramatic reductions to efficiency, damage output, and beam stability alongside a significantly increased physical size. However, for certain applications, such as point-defense emplacements, these trade-offs have been considered more than worthwhile.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Ktek_Beam",
@@ -473,7 +498,8 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@The Rlaan have studied disruptor based weaponry for far longer than any other extant species, and this is the most common fruit of that research.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Ktek_Beam_PD",
@@ -483,7 +509,8 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@A version of the Rlaan Ktek beam repurposed for point defense installations.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Ktek_Gun",
@@ -493,7 +520,8 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@Originally developed to break apart debris fields, this medium sized pulsed disruptor weapon is very deadly at close range. However, as the pulses, once disconnected from their generator, move slowly and rapidly decay, this weapon is of questionable value at any significant distance.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Ktek_Mini_Grav-thumper",
@@ -503,7 +531,8 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@What Rlaan do to the erstwhile laws of physics in their own homes is their own business. When they do it on the business end of this space-disrupting weapon, its everyone else's business to not be in the way. This miniature version of the Janissary class main weapon is used in lieu of torpedos by Rlaan assault craft.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Ktek_Mini_Grav-thumper_ammo",
@@ -513,7 +542,8 @@
         "volume": "1",
         "description": "@upgrades/maul.image@Unlike the larger version of the same device that the Janissary class is built around, the 'mini' version of the grav-thumper renders portions of the device used to generate the distortion damaged and inoperable. Fortunately, the relevant portions are both modular and easily ejected, leading to an ammunition-like solution to the problem.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Disruptor",
@@ -523,7 +553,8 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@A pulsed form of the shield-based disruptor beam technology, designs such as this have faded in popularity since the introduction of reliable shield decoupling mechanisms for the beam forms of disruptors. However, the significant time and investment already sunk into such designs, and the continued utility of the extremely high-end pulsed disruptor devices keeps the market stocked with current revisions of this aging weaponry.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Pugilist",
@@ -533,7 +564,8 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@The lightest and smallest of the disruptors manufactured by groups in Unadorned space, it can only provide body blows, but can keep on swinging with remarkable stamina.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Dissonance",
@@ -543,7 +575,8 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@A standard weapon on light Unadorned craft, the Dissonance is larger, weaker, and slower than the Rlaan Ktek gun, but has a significantly longer effective range.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "LR_Disruptor",
@@ -553,7 +586,8 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@Sacrificing efficiency and stopping power, this long ranged variant of the ubiquitous disruptor gun makes an effective fly-swatter. Primarily found in turret mounts on ships large enough to afford the energy demands, the low damage output tends to relegate this weapon to a deterrent role rather than the spearpoint of more aggressive actions.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Micro_Driver",
@@ -563,7 +597,8 @@
         "volume": "1",
         "description": "@upgrades/accelerator_gun.image@Long before the dawn of modern man, it was known to various hominids that hurling a blunt object was a reasonable way to deliver damage from a distance. Fittingly enough, the worlds of the Purist faction are among the chief manufacturers of mass drivers.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Mini_Driver",
@@ -573,7 +608,8 @@
         "volume": "1",
         "description": "@upgrades/accelerator_gun.image@Long before the dawn of modern man, it was known to various hominids that hurling a blunt object was a reasonable way to deliver damage from a distance. Fittingly enough, the worlds of the Purist faction are among the chief manufacturers of mass drivers.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Micro_Driver_ammo",
@@ -583,7 +619,8 @@
         "volume": "1",
         "description": "@upgrades/accelerator_gun.image@Very small, very dense, somewhat cheap, magnetically reactive.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Mini_Driver_ammo",
@@ -593,7 +630,8 @@
         "volume": "1",
         "description": "@upgrades/accelerator_gun.image@Small, dense, cheap, magnetically reactive.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Hephaestus_Mini",
@@ -603,7 +641,8 @@
         "volume": "0.1",
         "description": "@upgrades/accelerator_gun.image@A scaled down version of the electromagnetic accelerator used in the Hephaestus point defense emplacements, this Andolian death-dealer is special less in its ability to fling its projectiles rapidly and at high velocity than its compatibility with a very particular projectile of Andolian manufacture.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Hephaestus_Mini_ammo",
@@ -613,7 +652,8 @@
         "volume": "0.1",
         "description": "@upgrades/swarm.image@The ammunition for the Hephaestus mini-driver is by far one of the smallest and most advanced shield-piercing rounds developed to date.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "laser",
@@ -623,7 +663,8 @@
         "volume": "1",
         "description": "@upgrades/light.image@Though not a laser by any stretch of the imagination, due to its resemblance to the so called 'lasers' of classic games and movies of the previous millenium, the misnomer has stuck stronger than space rated epoxy. Cheap and utterly dependable, this and other similar low yield exhaust-compression weapons are ubiquitous in armed civilian populations.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Arc_Device",
@@ -633,7 +674,8 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@The trick, as many an unfortunate pirate has learned by experience, is to keep sufficient distance that the disabled enemy vessel is not accidently welded to your own ship. When used on security drones, the welding failure-mode is seen as more of a bonus.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "leech_gun",
@@ -643,7 +685,8 @@
         "volume": "1",
         "description": "@upgrades/beam2.image@Like the Crippler, the leech gun relies on sophisticated projectiles housing single-shot laser warheads and minimal targeting systems to do the dirty work of rendering a target vessel disabled. Unlike the Crippler, the leech gun has a reputation for being sufficiently underpowered that it's dangerous to not pack more lethal weaponry as well.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "crippler",
@@ -653,7 +696,8 @@
         "volume": "1",
         "description": "@upgrades/beam2.image@Originally designed for IntelSec and Homeland Security forces, the Crippler has reached increasingly large customer bases in the many decades since its introduction. Most experts believe this to be due to the fact that competitors looking to enter the less-than-lethal weapons market have tended to underestimate how difficult it is to hit appropriate subsystems to render a craft disabled but intact.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Plasma_Plume",
@@ -663,7 +707,8 @@
         "volume": "1",
         "description": "@upgrades/light.image@It's a (plasma) flamethrower! ... in space! If you can actually get close enough to hit anything, the ionization can disable all sort and manner of targetted electrical systems, but the plasma plume's range tends to limit its applications to relatively stationary objects. Cheap as vaccuum, flashy as a nova, and unlikely to cause any real harm, this is a favored weapon of rent-a-cops and parking enforcement officials everywhere. ",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Photon_MK_I",
@@ -673,7 +718,8 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@The oldest active armament of what would come to be a long series of Aeran PESC (Photon Emission on Shield Collapse) weapons, the gun itself is a non-descript warhead accelerator designed around the MK I PESC ammunition.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Photon_MK_II",
@@ -683,7 +729,8 @@
         "volume": "1",
         "description": "@upgrades/beam2.image@A significant improvement with respect to the MK I in both accelerator and warhead, the MK II is a briusing weapon with solid shield penetration still heavily in service across the entire Aeran fleet.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Photon_MK_III",
@@ -693,7 +740,8 @@
         "volume": "1",
         "description": "@upgrades/medium.image@A refinement, rather than an improvement over the MK II, the MK III is a smaller weapon based around a much smaller warhead and a faster rate of fire, extending the PESC weaponry to lighter Aeran craft and emplacements.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "razor_gun",
@@ -703,7 +751,8 @@
         "volume": "1",
         "description": "@upgrades/razor_gun.image@Sadly enough for their former marketing exectutives, 'Ring around the targets, pocket-size the fuzies, deuterium-deuterium, they all go boom!' did not in fact make for a good advertising campaign.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "reaper_cannon",
@@ -713,7 +762,8 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@The grimmest part of this Reaper is probably the 37 page manual on the appropriate handling of the anti-matter filled rounds. The gun itself, after all, is a rather sporty number.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Photon_MK_I_ammo",
@@ -723,7 +773,8 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@Aeran PESC (Photon Emission on Shield Collapse) Warhead. Essentially consisting of a faulty shield generator in miniature, on contact with any shield or object, the warhead's shield will collapse through the warhead itself, emitting a large number of high-energy photons in the process, thus lending notable shield-penetrating damage. While the root principle has been known to all of the major space-faring groups for some time, only the Aera have pursured significant weaponization.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Photon_MK_II_ammo",
@@ -733,7 +784,8 @@
         "volume": "1",
         "description": "@upgrades/beam2.image@Aeran PESC (Photon Emission on Shield Collapse) Warhead. Essentially consisting of a faulty shield generator in miniature, on contact with any shield or object, the warhead's shield will collapse through the warhead itself, emitting a large number of high-energy photons in the process, thus lending notable shield-penetrating damage. While the root principle has been known to all of the major space-faring groups for some time, only the Aera have pursured significant weaponization.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "Photon_MK_III_ammo",
@@ -743,7 +795,8 @@
         "volume": "1",
         "description": "@upgrades/medium.image@Aeran PESC (Photon Emission on Shield Collapse) Warhead. Essentially consisting of a faulty shield generator in miniature, on contact with any shield or object, the warhead's shield will collapse through the warhead itself, emitting a large number of high-energy photons in the process, thus lending notable shield-penetrating damage. While the root principle has been known to all of the major space-faring groups for some time, only the Aera have pursured significant weaponization.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "razor_gun_ammo",
@@ -753,7 +806,8 @@
         "volume": "1",
         "description": "@upgrades/razor_gun.image@Each Razor round is a miniature fusion device, and a real pain to get through customs.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "reaper_cannon_ammo",
@@ -763,7 +817,8 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@Keeping an anti-matter containment unit intact when being hurled out of a gun at several kilometers per second is no trivial matter, as the pricetag will verify.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "hellspawn",
@@ -773,7 +828,8 @@
         "volume": "1",
         "description": "@missile-hud.image@Echewing strong AI, the Rlaan rely on an engineered species derived from something akin to a hunting dog to pilot their drones. Most other species find the idea of giving disembodied pet brains firing control over energy weapons to be mildly disconcerting. The Hellspawn model is one of the smaller Rlaan drones, consisting of little more than two turrets, sensors, and a drive system. Survivability is not a priority, as evidenced by the sizeable self-destruct package.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "stormfire",
@@ -783,7 +839,8 @@
         "volume": "1",
         "description": "\"@upgrades/swarm.image@While individually fairly worthless, the PC-031 \"\"Stormfire\"\" rounds were designed as a low-yield, low-overhead projectiles that could be rapidly emmitted in high numbers by fighters with multiple weapon mountpoints, or as point defense on capital ships. Surplus Stormfires have seen additional use among merchants as cheap, reliable alternatives to energy weapons. \"",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "antimatter_gun",
@@ -793,7 +850,8 @@
         "volume": "1",
         "description": "@upgrades/medium.image@As may be expected of a device created to sling anti-matter, any error during the firing process will not merely slag the gun, but may evapourate it and a large portion of the vessel on which it is mounted; thus, every aspect of the process is perfectly controlled and subject to significant redundancy. Needless to say, such engineering does not come cheap.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "tractor_beam",
@@ -803,7 +861,8 @@
         "volume": "1",
         "description": "@cargo/tractor_beam.image@Gravitic technology can be used in a wide variety of ways: arguably, the most popular is keeping your soup in its bowl. A tractor beam, on the other hand, is good at putting somebody else's soup in your bowl. ",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "repulsor_beam",
@@ -813,7 +872,8 @@
         "volume": "1",
         "description": "@cargo/repulsor_beam.image@Repulsor beams, relatively new items on the market, have seen considerable use in large-scale construction projects ever since it was discovered how to keep them from mangling the point of contact; some creative combatants have found different uses for them.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "tractor_heavy",
@@ -823,7 +883,8 @@
         "volume": "1",
         "description": "@cargo/tractor_heavy.image@Animal magnetism is overrated.  This is just over-engineered. Capable of producing a g-forces that would turn people, elephants, and any appropriately hued fruits into raspberry colored toast topping, heavy tractor beams are rarely seen outside of deepspace construction yards and piracy organizations.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "tractor_capability",
@@ -833,7 +894,8 @@
         "volume": "1",
         "description": "@cargo/tractor_capability.image@Traditionally, most weapon mounts aren't constructed to handle the strains associated with tractor beam usage. Fortunately, this is usually a cost-cutting measure, and installing the necessary reinforcements doesn't tend to interfere with the weapon mount, although it may void certain warranties. ",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "autotracking",
@@ -843,7 +905,8 @@
         "volume": "1",
         "description": "@upgrades/circuit1.image@While all mounted weapons have inherent auto-tracking capabilities, these defaults are limited in civilian mounts. A full-powered military auto-tracker like this greatly enhances weapon accuracy.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "rlaan_turret_pd",
@@ -853,7 +916,8 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@The Rlaan are well known for their disdain of missiles, especially those fired at them.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "rlaan_turret_mini",
@@ -863,7 +927,8 @@
         "volume": "1",
         "description": "@upgrades/turret_medium.image@While Rlaan ships tend to mount flash-shields capable of shrugging off most small arms fire, they still prefer the option of 'convincing' fighters to stop firing.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "aera_turret_pd",
@@ -873,7 +938,8 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@Using low yield pulse lasers, the aera have made simple and effective anti-missile turrets.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "beam_turret",
@@ -883,7 +949,8 @@
         "volume": "1",
         "description": "@upgrades/turret_heavy.image@Specially designed for the energy and heat dissipation requirements of beam weapons, this turret has everything you need to mount a pair of them.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "turret_pd",
@@ -893,7 +960,8 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@One is heavily advised to not play 'catch the missile' unless one mounts several of these.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "heavy_turret",
@@ -903,7 +971,8 @@
         "volume": "1",
         "description": "@upgrades/turret_heavy.image@For when evasive maneuvers are too subtle a hint your tailgaters.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "small_turret",
@@ -913,7 +982,8 @@
         "volume": "1",
         "description": "@upgrades/turret_light.image@Given the armament commonly placed in such turrets, the small turret has become affectionately known as 'the machine that goes ping'.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "medium_turret",
@@ -923,7 +993,8 @@
         "volume": "1",
         "description": "@upgrades/turret_medium.image@It turns, it shoots, it slices. No, it does not dice, but it does come with a free fuzzy pair.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "capship_turret",
@@ -933,7 +1004,8 @@
         "volume": "1",
         "description": "@upgrades/razor_gun.image@When hunting for bear, hover softly, and carry a big stick",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "capship_turret_heavy",
@@ -943,7 +1015,8 @@
         "volume": "1",
         "description": "@upgrades/beam2.image@If your vessel can mount this, this can mount whatever you want.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "turret_pd_long",
@@ -953,7 +1026,8 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@One of the most impressive applications of disruptor technology, this military rated point defense turret is the best of its kind.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "franklin_pd",
@@ -963,7 +1037,8 @@
         "volume": "1",
         "description": "@../units/franklin/franklin-hud.image@These turrets were custom designed for the Franklin class diplomatic transport. Any hotshot who splurges on the Franklin should undoubtedly get these fine turrets to complement the exterior decor.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "kineticmissile",
@@ -973,7 +1048,8 @@
         "volume": "0.1",
         "description": "@missile-hud.image@Behold KE=1/2MV^2: large values of M and high values of V yield large numbers of obliterated fragments of intended targets. (Capital sized launch platform sold separately, shield batteries included.)",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "capiff_ammo",
@@ -983,7 +1059,8 @@
         "volume": "0.1",
         "description": "@upgrades/capiff.image@Drawing upon the greater sensor capability and volumetric resources of a capital vessel, these larger IFF missiles can deliver a larger payload over a much longer intercept sphere than their fighter-launched cousins.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "cap_iff",
@@ -993,7 +1070,8 @@
         "volume": "0.1",
         "description": "@upgrades/capiff.image@Drawing upon the greater sensor capability and volumetric resources of a capital vessel, these larger IFF missiles can deliver a larger payload over a much longer intercept sphere than their fighter-launched cousins.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "capcluster_ammo",
@@ -1003,7 +1081,8 @@
         "volume": "0.1",
         "description": "@upgrades/missile.image@Capital ships benefit both from being large enough to launch effective cluster munitions and robust enough to not worry about doorstep detonations.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "capshipmissile_ammo",
@@ -1013,7 +1092,8 @@
         "volume": "0.1",
         "description": "@upgrades/capshipmissile.image@As large as some insystem fighters and sporting the latest in stealth and ECCM technology, these SPEC capable missiles, frequently seen tipped with warheads in the 10 megaton or higher range, can make dropping one's shields to retreat a truly nerve-wracking decision.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "grand_gauss",
@@ -1023,7 +1103,8 @@
         "volume": "0.1",
         "description": "@upgrades/emp2.image@The spinal mounted armament of the Leonidas class dreadnaughts is something to behold. If the principle behind the massive accelerators is not novel, their scale remains awe-inspiring.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "dumbfire_ammo",
@@ -1033,7 +1114,8 @@
         "volume": "0.1",
         "description": "@upgrades/dumbfire.image@Removing maneuvering jets capable of counteracting a missile's momentum leaves a lot more room for a warhead. Of course, it also makes for a missile that only flies in a straight line.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "heatseeker_ammo",
@@ -1043,7 +1125,8 @@
         "volume": "0.1",
         "description": "@upgrades/heatseeker.image@A missile which locks onto a heat source -- a ship's engines, for example -- rather than a radar or IFF signal. The Heatseeker is not as vulnerable to ECM as torpedoes, IFF or other guided missiles are. Damage is respectable for their small size. They are also relatively inexpensive and widely available. Most effective against light and medium ships. They are best used in salvos rather than individually. One missile often will weaken the target's defenses enough to let the others get through and do damage to the ship itself. CAUTION: If you are attacking targets near a friendly capship, heat seekers launched at targets within a few hundred meters from the capship may well lock onto the capship instead. That tends to get you talked about by the capship. ",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "image_recognition_ammo",
@@ -1053,7 +1136,8 @@
         "volume": "0.1",
         "description": "@upgrades/imrec.image@Like an obsessive-compulsive stalker, once it knows what you look like, it's not going to stop showing up at your doorstep.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "friend_or_foe_ammo",
@@ -1063,7 +1147,8 @@
         "volume": "0.1",
         "description": "@upgrades/fof.image@There are those who, steadfast in their desire to reduce signals cluttering battlefield communications, have advocated abandoning traditional IFF mechanisms. Fortunately for missile and sensor manufacturers everywhere, such proponents have a remarkable tendency to find their ships hit by IFF missiles.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "torpedo_ammo",
@@ -1073,7 +1158,8 @@
         "volume": "0.1",
         "description": "@upgrades/emp1.image@Featuring bulk and drive style rapidly approaching that of a small vessel, these beasts pack a heavy punch, but tend to have acceleration curves suited to catching only the less than fleet of foot.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "advtorpedo_ammo",
@@ -1083,7 +1169,8 @@
         "volume": "0.1",
         "description": "@upgrades/missile.image@The Aeran equivalent of the Confederation torpedo is just as sluggish, but packs a more vicious punch.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "emp_torpedo_ammo",
@@ -1093,7 +1180,8 @@
         "volume": "0.1",
         "description": "@upgrades/emp3.image@Employed in increasingly large numbers by regional guard units, EMP torpedos seek to sufficiently damage the electronics of a vessel so as to render it out of user control. Such devices, in the absence of an atmosphere to assist with EMP effects, must be quite large, and have thus been adapted to a torpedo chassis.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "javelin_ammo",
@@ -1103,7 +1191,8 @@
         "volume": "0.1",
         "description": "@upgrades/swarm.image@An older Aeran PESC mini-warhead adapted for rocket pod distribution.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "cluster_ammo",
@@ -1113,7 +1202,8 @@
         "volume": "0.1",
         "description": "@upgrades/cluster.image@While fighter-mounted cluster missiles are unlikely to actually destroy any vessels, they are extremely useful for getting the attention of several craft in one go.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "swarm_ammo",
@@ -1123,7 +1213,8 @@
         "volume": "0.1",
         "description": "@upgrades/swarm.image@If you love the smell of Katyushas in the morning, then you probably already have one of these.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "photon_swarm_ammo",
@@ -1133,7 +1224,8 @@
         "volume": "0.1",
         "description": "@upgrades/swarm.image@A more recently developed Aeran PESC mini-warhead, photon swarm rocket pods are extremely common on Aeran light craft.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "killer_bee_ammo",
@@ -1143,7 +1235,8 @@
         "volume": "0.1",
         "description": "@upgrades/swarm.image@Like their namesake, one sting won't hurt too much, but nobody fires just one of these.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "hail_ammo",
@@ -1153,7 +1246,8 @@
         "volume": "0.1",
         "description": "@upgrades/swarm.image@Sometimes it rains, sometimes it hails, but when you're armed with Hail emplacents, it rains death from above.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "breeze_ammo",
@@ -1163,7 +1257,8 @@
         "volume": "0.1",
         "description": "@upgrades/missile.image@An otherwise unremarkable missile with an odd aspect ratio.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "porcupine_mine_ammo",
@@ -1173,7 +1268,8 @@
         "volume": "0.1",
         "description": "@upgrades/porcupine_mine.image@Dropped by Aeran mine-layers and, in smaller numbers, other small craft, these mines each mount a single gun with a limited number of rounds. Once ammunition or energy is depleted, the mines self-destruct. These mines are used in both defensive emplacements and as a harassing distraction against pursuing craft.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "leech_ammo",
@@ -1183,7 +1279,8 @@
         "volume": "1",
         "description": "@upgrades/leech.image@Complicated rounds with sensors and one-shot lasers designed to disable, not destroy, enemy craft.",
         "upgrade": true,
-        "weapoon": true
+        "weapoon": true,
+        "weapon": true
     },
     {
         "file": "cloaking_device",

--- a/master_component_list.json
+++ b/master_component_list.json
@@ -5,7 +5,8 @@
         "price": "12000",
         "mass": "0",
         "volume": "0",
-        "description": "@cargo/hull_patches.image@The ship's hull."
+        "description": "@cargo/hull_patches.image@The ship's hull.",
+        "upgrade": true
     },
     {
         "file": "afterburner",
@@ -13,7 +14,8 @@
         "price": "2000",
         "mass": "0",
         "volume": "0",
-        "description": "@upgrades/afterburner_generic.image@Engine overdrive. Increases thrust at the expense of decreased fuel efficiency."
+        "description": "@upgrades/afterburner_generic.image@Engine overdrive. Increases thrust at the expense of decreased fuel efficiency.",
+        "upgrade": true
     },
     {
         "file": "drive",
@@ -21,7 +23,8 @@
         "price": "6000",
         "mass": "0",
         "volume": "0",
-        "description": "@upgrades/afterburner_generic.image@The ship's engine."
+        "description": "@upgrades/afterburner_generic.image@The ship's engine.",
+        "upgrade": true
     },
     {
         "file": "ftl_drive",
@@ -29,17 +32,17 @@
         "price": "4500",
         "mass": "0",
         "volume": "0",
-        "description": "@upgrades/jump_drive.image@The ship's faster than light engine."
+        "description": "@upgrades/jump_drive.image@The ship's faster than light engine.",
+        "upgrade": true
     },
-    
-    
     {
         "file": "Areus_Milspec_Package",
         "categoryname": "upgrades/Packages/Milspec",
         "price": "4000000",
         "mass": "216",
         "volume": "4400",
-        "description": "Full-Custom Milspec Configuration"
+        "description": "Full-Custom Milspec Configuration",
+        "upgrade": true
     },
     {
         "file": "Ariston_Milspec_Package",
@@ -47,7 +50,8 @@
         "price": "2500000",
         "mass": "197",
         "volume": "4000",
-        "description": "Full-Custom Milspec Configuration"
+        "description": "Full-Custom Milspec Configuration",
+        "upgrade": true
     },
     {
         "file": "Clydesdale_Milspec_Package",
@@ -55,7 +59,8 @@
         "price": "200000000",
         "mass": "29000000",
         "volume": "590000000",
-        "description": "Full-Custom Milspec Configuration"
+        "description": "Full-Custom Milspec Configuration",
+        "upgrade": true
     },
     {
         "file": "Convolution_Milspec_Package",
@@ -63,7 +68,8 @@
         "price": "1000000",
         "mass": "62",
         "volume": "1280",
-        "description": "Full-Custom Milspec Configuration"
+        "description": "Full-Custom Milspec Configuration",
+        "upgrade": true
     },
     {
         "file": "Derivative_Milspec_Package",
@@ -71,7 +77,8 @@
         "price": "800000",
         "mass": "134",
         "volume": "2700",
-        "description": "Full-Custom Milspec Configuration"
+        "description": "Full-Custom Milspec Configuration",
+        "upgrade": true
     },
     {
         "file": "Determinant_Milspec_Package",
@@ -79,7 +86,8 @@
         "price": "800000",
         "mass": "54",
         "volume": "1100",
-        "description": "Full-Custom Milspec Configuration"
+        "description": "Full-Custom Milspec Configuration",
+        "upgrade": true
     },
     {
         "file": "Dodo_Milspec_Package",
@@ -87,7 +95,8 @@
         "price": "90000",
         "mass": "1096",
         "volume": "21000",
-        "description": "Full-Custom Milspec Configuration"
+        "description": "Full-Custom Milspec Configuration",
+        "upgrade": true
     },
     {
         "file": "Dostoevsky_Milspec_Package",
@@ -95,7 +104,8 @@
         "price": "350000",
         "mass": "63",
         "volume": "1300",
-        "description": "Full-Custom Milspec Configuration"
+        "description": "Full-Custom Milspec Configuration",
+        "upgrade": true
     },
     {
         "file": "Franklin_Milspec_Package",
@@ -103,7 +113,8 @@
         "price": "1200000",
         "mass": "575",
         "volume": "12000",
-        "description": "Full-Custom Milspec Configuration"
+        "description": "Full-Custom Milspec Configuration",
+        "upgrade": true
     },
     {
         "file": "Gawain_Milspec_Package",
@@ -111,7 +122,8 @@
         "price": "3000000",
         "mass": "40",
         "volume": "800",
-        "description": "Full-Custom Milspec Configuration"
+        "description": "Full-Custom Milspec Configuration",
+        "upgrade": true
     },
     {
         "file": "Goddard_Milspec_Package",
@@ -119,7 +131,8 @@
         "price": "7000000",
         "mass": "2150",
         "volume": "43000",
-        "description": "Full-Custom Milspec Configuration"
+        "description": "Full-Custom Milspec Configuration",
+        "upgrade": true
     },
     {
         "file": "Lancelot_Milspec_Package",
@@ -127,7 +140,8 @@
         "price": "4000000",
         "mass": "170",
         "volume": "3500",
-        "description": "Full-Custom Milspec Configuration"
+        "description": "Full-Custom Milspec Configuration",
+        "upgrade": true
     },
     {
         "file": "Mule_Milspec_Package",
@@ -135,7 +149,8 @@
         "price": "6000000",
         "mass": "20000",
         "volume": "570000",
-        "description": "Full-Custom Milspec Configuration"
+        "description": "Full-Custom Milspec Configuration",
+        "upgrade": true
     },
     {
         "file": "Nicander_Milspec_Package",
@@ -143,7 +158,8 @@
         "price": "2100000",
         "mass": "132",
         "volume": "2700",
-        "description": "Full-Custom Milspec Configuration"
+        "description": "Full-Custom Milspec Configuration",
+        "upgrade": true
     },
     {
         "file": "Pacifier_Milspec_Package",
@@ -151,7 +167,8 @@
         "price": "800000",
         "mass": "490",
         "volume": "10000",
-        "description": "Full-Custom Milspec Configuration"
+        "description": "Full-Custom Milspec Configuration",
+        "upgrade": true
     },
     {
         "file": "Progeny_Milspec_Package",
@@ -159,7 +176,8 @@
         "price": "800000",
         "mass": "62",
         "volume": "1200",
-        "description": "Full-Custom Milspec Configuration"
+        "description": "Full-Custom Milspec Configuration",
+        "upgrade": true
     },
     {
         "file": "Schroedinger_Milspec_Package",
@@ -167,7 +185,8 @@
         "price": "2000000",
         "mass": "80",
         "volume": "1600",
-        "description": "Full-Custom Milspec Configuration"
+        "description": "Full-Custom Milspec Configuration",
+        "upgrade": true
     },
     {
         "file": "Shizu_Milspec_Package",
@@ -175,7 +194,8 @@
         "price": "200000",
         "mass": "57",
         "volume": "1140",
-        "description": "Full-Custom Milspec Configuration"
+        "description": "Full-Custom Milspec Configuration",
+        "upgrade": true
     },
     {
         "file": "Taizong_Milspec_Package",
@@ -183,7 +203,8 @@
         "price": "3500000",
         "mass": "230",
         "volume": "4600",
-        "description": "Full-Custom Milspec Configuration"
+        "description": "Full-Custom Milspec Configuration",
+        "upgrade": true
     },
     {
         "file": "Zhuangzong_Milspec_Package",
@@ -191,17 +212,18 @@
         "price": "1400000",
         "mass": "65",
         "volume": "1300",
-        "description": "Full-Custom Milspec Configuration"
+        "description": "Full-Custom Milspec Configuration",
+        "upgrade": true
     },
-    
-    
     {
         "file": "beam_heavy_lr",
         "categoryname": "upgrades/Weapons/Capship",
         "price": "2500000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam1.image@The logical conclusion of decades of upscaling work with spatial disruption technology, this weapon finds its home only among the weapons mounted on the capital vessels of well funded space navies."
+        "description": "@upgrades/beam1.image@The logical conclusion of decades of upscaling work with spatial disruption technology, this weapon finds its home only among the weapons mounted on the capital vessels of well funded space navies.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "flak",
@@ -209,7 +231,9 @@
         "price": "6500",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam2.image@Like fireworks - only full of razorblades."
+        "description": "@upgrades/beam2.image@Like fireworks - only full of razorblades.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "flak_heavy",
@@ -217,7 +241,9 @@
         "price": "9500",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam3.image@There, there Snowden.... there, there."
+        "description": "@upgrades/beam3.image@There, there Snowden.... there, there.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "lr_disruptor_beam",
@@ -225,7 +251,9 @@
         "price": "120000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam1.image@A variant of the Disruptor Beam, this weapon uses the same functional principals, but is engineered for use at long range. Projecting something that is, in many respects, an extremely long sliver of a shield poses a number of technical difficulties. Long range disruptor beams increase the effective range of the weapon, but at the cost of dramatic reductions to efficiency, damage output, and beam stability alongside a significantly increased physical size. However, for certain applications, such as point-defense emplacements, these trade-offs have been considered more than worthwhile."
+        "description": "@upgrades/beam1.image@A variant of the Disruptor Beam, this weapon uses the same functional principals, but is engineered for use at long range. Projecting something that is, in many respects, an extremely long sliver of a shield poses a number of technical difficulties. Long range disruptor beams increase the effective range of the weapon, but at the cost of dramatic reductions to efficiency, damage output, and beam stability alongside a significantly increased physical size. However, for certain applications, such as point-defense emplacements, these trade-offs have been considered more than worthwhile.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Relativistic_Particle_Beam",
@@ -233,7 +261,9 @@
         "price": "250000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/medium.image@While slinging particles of negligible mass, and in chaste quantities, this weapon does manage to propel them at significant fractions of lightspeed, rendering the particles quite dangerous to encounter."
+        "description": "@upgrades/medium.image@While slinging particles of negligible mass, and in chaste quantities, this weapon does manage to propel them at significant fractions of lightspeed, rendering the particles quite dangerous to encounter.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "photon_capship",
@@ -241,7 +271,9 @@
         "price": "2500000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/heavy.image@The standard armament of most heavy Aeran vessels, this is a scaled up version of the same PESC type warhead delivery system used in Aeran combat craft."
+        "description": "@upgrades/heavy.image@The standard armament of most heavy Aeran vessels, this is a scaled up version of the same PESC type warhead delivery system used in Aeran combat craft.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "rlr_laser_beam",
@@ -249,7 +281,9 @@
         "price": "150000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/medium.image@A long ranged laser weapon used primarily in Aeran point defence emplacements."
+        "description": "@upgrades/medium.image@A long ranged laser weapon used primarily in Aeran point defence emplacements.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "FS_MWRF_Laser",
@@ -257,7 +291,9 @@
         "price": "20000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/medium.image@Rapid-fire microwave laser: When an enemy vessel has had enough it will go 'ding'. Or, possibly, explode."
+        "description": "@upgrades/medium.image@Rapid-fire microwave laser: When an enemy vessel has had enough it will go 'ding'. Or, possibly, explode.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "FS_MW_Laser",
@@ -265,7 +301,9 @@
         "price": "20000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/heavy.image@Microwave laser: Caution -- do not stand in front of laser when attempting to defrost chickens."
+        "description": "@upgrades/heavy.image@Microwave laser: Caution -- do not stand in front of laser when attempting to defrost chickens.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "FS_IRRF_Laser",
@@ -273,7 +311,9 @@
         "price": "26000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/heavy.image@Rapid-fire infrared laser: Even on the coldest sea, it can still be Hot, Hot, Hot!"
+        "description": "@upgrades/heavy.image@Rapid-fire infrared laser: Even on the coldest sea, it can still be Hot, Hot, Hot!",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "FS_IR_Laser",
@@ -281,7 +321,9 @@
         "price": "26000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/heavy.image@Infrared laser: When using for grilling, please refrain from putting hands, feet, or population centers in front of the lasing surface."
+        "description": "@upgrades/heavy.image@Infrared laser: When using for grilling, please refrain from putting hands, feet, or population centers in front of the lasing surface.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Jackhammer",
@@ -289,7 +331,9 @@
         "price": "24000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam3.image@The Jackhammer is an open-cycle laser, venting its coolant after every firing sequence. While this does wonders for the size and complexity of the cooling system, it does raise ammunition capacity issues not frequently associated with modern lasers."
+        "description": "@upgrades/beam3.image@The Jackhammer is an open-cycle laser, venting its coolant after every firing sequence. While this does wonders for the size and complexity of the cooling system, it does raise ammunition capacity issues not frequently associated with modern lasers.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Jackhammer_ammo",
@@ -297,7 +341,9 @@
         "price": "20",
         "mass": "0.01",
         "volume": "1",
-        "description": "@cargo/halogen_gasses.image@Coolant for the open-cycle Jackhammer laser."
+        "description": "@cargo/halogen_gasses.image@Coolant for the open-cycle Jackhammer laser.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "CS_UVRF_Laser",
@@ -305,7 +351,9 @@
         "price": "75000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/turret_heavy.image@Rapid-fire UV Laser. UV and other higher frequency lasers raise increasing concerns about cooling. Fortunately, UV and higher frequency lasers are effective enough to warrant being built into capital sized mounts that can handle their cooling requirements."
+        "description": "@upgrades/turret_heavy.image@Rapid-fire UV Laser. UV and other higher frequency lasers raise increasing concerns about cooling. Fortunately, UV and higher frequency lasers are effective enough to warrant being built into capital sized mounts that can handle their cooling requirements.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "CS_UV_Laser",
@@ -313,7 +361,9 @@
         "price": "75000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/turret_heavy.image@UV Laser. Unlike most exposures to UV light, taking in these rays decreases the risk of dying from skin cancer."
+        "description": "@upgrades/turret_heavy.image@UV Laser. Unlike most exposures to UV light, taking in these rays decreases the risk of dying from skin cancer.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "CS_XRRF_Laser",
@@ -321,7 +371,9 @@
         "price": "2500000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/turret_heavy.image@Rapid-fire Xaser. Used properly, one can use a Xaser to figure out what the inside of an enemy vessel looks like. The crew, however, tends to cease to have insides at about the same time."
+        "description": "@upgrades/turret_heavy.image@Rapid-fire Xaser. Used properly, one can use a Xaser to figure out what the inside of an enemy vessel looks like. The crew, however, tends to cease to have insides at about the same time.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "CS_XR_Laser",
@@ -329,7 +381,9 @@
         "price": "2500000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/turret_heavy.image@Xaser. The X-ray spectrum and lasers are notoriously unfriendly to being combined. That xasers exist at all just goes to show that some relationships can be made to work if there's enough money in it for everyone else involved."
+        "description": "@upgrades/turret_heavy.image@Xaser. The X-ray spectrum and lasers are notoriously unfriendly to being combined. That xasers exist at all just goes to show that some relationships can be made to work if there's enough money in it for everyone else involved.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Particle_Beam",
@@ -337,7 +391,9 @@
         "price": "7500",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/medium.image@It has long been known that lightweight, charged particles, while easy to accelerate, suffer greatly from electro-static bloom effects. However, it has also long been known that there's not much in the universe cheaper to obtain than lightweight, charged particles. Still, it's not your great-to-the-Nth-granddaddy's cathode ray tube. (It's a lot bigger than that)."
+        "description": "@upgrades/medium.image@It has long been known that lightweight, charged particles, while easy to accelerate, suffer greatly from electro-static bloom effects. However, it has also long been known that there's not much in the universe cheaper to obtain than lightweight, charged particles. Still, it's not your great-to-the-Nth-granddaddy's cathode ray tube. (It's a lot bigger than that).",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Ion_Beam",
@@ -345,7 +401,9 @@
         "price": "16000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/medium.image@Adding a bit more heft to the input stream than what is found in weapons termed particle beams, this weapon nonetheless operates on the same general principles. The electric charge of ionized plasma makes it particularly easy to compress and fire using simple magnetics. Deceptively simple in design, these weapons' cost comes from the inherent difficulty in making a stream of ionized plasma remain coherent _after_ firing. In the last ten years, advances in this field have led to noted increases in the accessibility of ion beam weapons, and to a market glut of cheap knockoff brands."
+        "description": "@upgrades/medium.image@Adding a bit more heft to the input stream than what is found in weapons termed particle beams, this weapon nonetheless operates on the same general principles. The electric charge of ionized plasma makes it particularly easy to compress and fire using simple magnetics. Deceptively simple in design, these weapons' cost comes from the inherent difficulty in making a stream of ionized plasma remain coherent _after_ firing. In the last ten years, advances in this field have led to noted increases in the accessibility of ion beam weapons, and to a market glut of cheap knockoff brands.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Heavy_Ion_Beam",
@@ -353,7 +411,9 @@
         "price": "25000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/heavy.image@A variant of the somewhat more common Ion Beam, these weapons utilizes heavier ions, such as xenon. Heavier ions are more difficult to accelerate to the desired exit velocities, but do not suffer nearly as much from electro-static bloom effects as their lighter counterparts."
+        "description": "@upgrades/heavy.image@A variant of the somewhat more common Ion Beam, these weapons utilizes heavier ions, such as xenon. Heavier ions are more difficult to accelerate to the desired exit velocities, but do not suffer nearly as much from electro-static bloom effects as their lighter counterparts.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Ion_Burster",
@@ -361,7 +421,9 @@
         "price": "7000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam2.image@One of the smallest of the ion weapon family, the Ion Burster, despite a seemingly projectile output, is more closely related to ion beam weapons than to anything else. Indeed, the lower speed and packetized nature of the weapon's output are not so much desirable attributes as concessions: in order to make the weapon small enough to meet design specifications, the beam can only be pulsed, and infrequently at that. To compensate for this disability, the Ion Burster relies on specially prepared vaporization plates, rather than the homogeneous gas-streams ususally feeding Ion weapons."
+        "description": "@upgrades/beam2.image@One of the smallest of the ion weapon family, the Ion Burster, despite a seemingly projectile output, is more closely related to ion beam weapons than to anything else. Indeed, the lower speed and packetized nature of the weapon's output are not so much desirable attributes as concessions: in order to make the weapon small enough to meet design specifications, the beam can only be pulsed, and infrequently at that. To compensate for this disability, the Ion Burster relies on specially prepared vaporization plates, rather than the homogeneous gas-streams ususally feeding Ion weapons.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Ion_Burster_ammo",
@@ -369,7 +431,9 @@
         "price": "4",
         "mass": "0.01",
         "volume": "1",
-        "description": "@cargo/halogen_gasses.image@Prepackaged vaporization plates for the Ion Burster gun."
+        "description": "@cargo/halogen_gasses.image@Prepackaged vaporization plates for the Ion Burster gun.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Disruptor_Beam",
@@ -377,7 +441,9 @@
         "price": "45000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam1.image@The canonical example of shield-based weaponry, the disruptor beam is highly effective at disrupting the twisted maze of forces created by a shield generator, but entirely unequipped to trickle damage past a shield until the shield in question has already nearly faltered. Disruptors, just like the shields they share most of their technological lineage with, interact violently with matter, making them poorly suited to use outside of vacuum. Fortunately for those on the receiving end of a disruptor blast, even a shield de-patterned to the point of collapse will mitigate a disruptor's effects on materials beyond the shield. Unfortunately for those on the receiving end of a disruptor, mitigate is not the same as eliminate. Those unfortunate enough to receive disruptor fire with no shield generator at all are usually at least fortunate enough that the shear forces kill them before they can notice. This design is exceptionally popular among adherents to the trekkie religion, but its reliability and effectiveness make it nothing to scoff at."
+        "description": "@upgrades/beam1.image@The canonical example of shield-based weaponry, the disruptor beam is highly effective at disrupting the twisted maze of forces created by a shield generator, but entirely unequipped to trickle damage past a shield until the shield in question has already nearly faltered. Disruptors, just like the shields they share most of their technological lineage with, interact violently with matter, making them poorly suited to use outside of vacuum. Fortunately for those on the receiving end of a disruptor blast, even a shield de-patterned to the point of collapse will mitigate a disruptor's effects on materials beyond the shield. Unfortunately for those on the receiving end of a disruptor, mitigate is not the same as eliminate. Those unfortunate enough to receive disruptor fire with no shield generator at all are usually at least fortunate enough that the shear forces kill them before they can notice. This design is exceptionally popular among adherents to the trekkie religion, but its reliability and effectiveness make it nothing to scoff at.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Shield_Breaker",
@@ -385,7 +451,9 @@
         "price": "400000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam3.image@This Highborn Milspec weapon was designed alongside the Lancelot superiority fighter. If nearly equivalent in fundamental design principles, its implementation and engineering is superior in nearly every respect to the Disruptor Beams it shares a common origin with. In keeping with the naming of the ship it was co-designed with, the Shield Breaker is well suited to render any shield within reach quite humbled in but a small number of lancing blows."
+        "description": "@upgrades/beam3.image@This Highborn Milspec weapon was designed alongside the Lancelot superiority fighter. If nearly equivalent in fundamental design principles, its implementation and engineering is superior in nearly every respect to the Disruptor Beams it shares a common origin with. In keeping with the naming of the ship it was co-designed with, the Shield Breaker is well suited to render any shield within reach quite humbled in but a small number of lancing blows.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "LR_Disruptor_Beam",
@@ -393,7 +461,9 @@
         "price": "1200000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/heavy.image@A variant of the Disruptor Beam, this weapon uses the same functional principals, but is engineered for use at long range. Projecting something that is, in many respects, an extremely long sliver of a shield poses a number of technical difficulties. Long range disruptor beams increase the effective range of the weapon, but at the cost of dramatic reductions to efficiency, damage output, and beam stability alongside a significantly increased physical size. However, for certain applications, such as point-defense emplacements, these trade-offs have been considered more than worthwhile."
+        "description": "@upgrades/heavy.image@A variant of the Disruptor Beam, this weapon uses the same functional principals, but is engineered for use at long range. Projecting something that is, in many respects, an extremely long sliver of a shield poses a number of technical difficulties. Long range disruptor beams increase the effective range of the weapon, but at the cost of dramatic reductions to efficiency, damage output, and beam stability alongside a significantly increased physical size. However, for certain applications, such as point-defense emplacements, these trade-offs have been considered more than worthwhile.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Ktek_Beam",
@@ -401,7 +471,9 @@
         "price": "1200000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam1.image@The Rlaan have studied disruptor based weaponry for far longer than any other extant species, and this is the most common fruit of that research."
+        "description": "@upgrades/beam1.image@The Rlaan have studied disruptor based weaponry for far longer than any other extant species, and this is the most common fruit of that research.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Ktek_Beam_PD",
@@ -409,7 +481,9 @@
         "price": "400000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam1.image@A version of the Rlaan Ktek beam repurposed for point defense installations."
+        "description": "@upgrades/beam1.image@A version of the Rlaan Ktek beam repurposed for point defense installations.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Ktek_Gun",
@@ -417,7 +491,9 @@
         "price": "200000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam3.image@Originally developed to break apart debris fields, this medium sized pulsed disruptor weapon is very deadly at close range. However, as the pulses, once disconnected from their generator, move slowly and rapidly decay, this weapon is of questionable value at any significant distance."
+        "description": "@upgrades/beam3.image@Originally developed to break apart debris fields, this medium sized pulsed disruptor weapon is very deadly at close range. However, as the pulses, once disconnected from their generator, move slowly and rapidly decay, this weapon is of questionable value at any significant distance.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Ktek_Mini_Grav-thumper",
@@ -425,7 +501,9 @@
         "price": "200000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam3.image@What Rlaan do to the erstwhile laws of physics in their own homes is their own business. When they do it on the business end of this space-disrupting weapon, its everyone else's business to not be in the way. This miniature version of the Janissary class main weapon is used in lieu of torpedos by Rlaan assault craft."
+        "description": "@upgrades/beam3.image@What Rlaan do to the erstwhile laws of physics in their own homes is their own business. When they do it on the business end of this space-disrupting weapon, its everyone else's business to not be in the way. This miniature version of the Janissary class main weapon is used in lieu of torpedos by Rlaan assault craft.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Ktek_Mini_Grav-thumper_ammo",
@@ -433,7 +511,9 @@
         "price": "60000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/maul.image@Unlike the larger version of the same device that the Janissary class is built around, the 'mini' version of the grav-thumper renders portions of the device used to generate the distortion damaged and inoperable. Fortunately, the relevant portions are both modular and easily ejected, leading to an ammunition-like solution to the problem."
+        "description": "@upgrades/maul.image@Unlike the larger version of the same device that the Janissary class is built around, the 'mini' version of the grav-thumper renders portions of the device used to generate the distortion damaged and inoperable. Fortunately, the relevant portions are both modular and easily ejected, leading to an ammunition-like solution to the problem.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Disruptor",
@@ -441,7 +521,9 @@
         "price": "60000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam1.image@A pulsed form of the shield-based disruptor beam technology, designs such as this have faded in popularity since the introduction of reliable shield decoupling mechanisms for the beam forms of disruptors. However, the significant time and investment already sunk into such designs, and the continued utility of the extremely high-end pulsed disruptor devices keeps the market stocked with current revisions of this aging weaponry."
+        "description": "@upgrades/beam1.image@A pulsed form of the shield-based disruptor beam technology, designs such as this have faded in popularity since the introduction of reliable shield decoupling mechanisms for the beam forms of disruptors. However, the significant time and investment already sunk into such designs, and the continued utility of the extremely high-end pulsed disruptor devices keeps the market stocked with current revisions of this aging weaponry.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Pugilist",
@@ -449,7 +531,9 @@
         "price": "75000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam1.image@The lightest and smallest of the disruptors manufactured by groups in Unadorned space, it can only provide body blows, but can keep on swinging with remarkable stamina."
+        "description": "@upgrades/beam1.image@The lightest and smallest of the disruptors manufactured by groups in Unadorned space, it can only provide body blows, but can keep on swinging with remarkable stamina.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Dissonance",
@@ -457,7 +541,9 @@
         "price": "500000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam1.image@A standard weapon on light Unadorned craft, the Dissonance is larger, weaker, and slower than the Rlaan Ktek gun, but has a significantly longer effective range."
+        "description": "@upgrades/beam1.image@A standard weapon on light Unadorned craft, the Dissonance is larger, weaker, and slower than the Rlaan Ktek gun, but has a significantly longer effective range.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "LR_Disruptor",
@@ -465,7 +551,9 @@
         "price": "400000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam1.image@Sacrificing efficiency and stopping power, this long ranged variant of the ubiquitous disruptor gun makes an effective fly-swatter. Primarily found in turret mounts on ships large enough to afford the energy demands, the low damage output tends to relegate this weapon to a deterrent role rather than the spearpoint of more aggressive actions."
+        "description": "@upgrades/beam1.image@Sacrificing efficiency and stopping power, this long ranged variant of the ubiquitous disruptor gun makes an effective fly-swatter. Primarily found in turret mounts on ships large enough to afford the energy demands, the low damage output tends to relegate this weapon to a deterrent role rather than the spearpoint of more aggressive actions.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Micro_Driver",
@@ -473,7 +561,9 @@
         "price": "10000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/accelerator_gun.image@Long before the dawn of modern man, it was known to various hominids that hurling a blunt object was a reasonable way to deliver damage from a distance. Fittingly enough, the worlds of the Purist faction are among the chief manufacturers of mass drivers."
+        "description": "@upgrades/accelerator_gun.image@Long before the dawn of modern man, it was known to various hominids that hurling a blunt object was a reasonable way to deliver damage from a distance. Fittingly enough, the worlds of the Purist faction are among the chief manufacturers of mass drivers.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Mini_Driver",
@@ -481,7 +571,9 @@
         "price": "15000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/accelerator_gun.image@Long before the dawn of modern man, it was known to various hominids that hurling a blunt object was a reasonable way to deliver damage from a distance. Fittingly enough, the worlds of the Purist faction are among the chief manufacturers of mass drivers."
+        "description": "@upgrades/accelerator_gun.image@Long before the dawn of modern man, it was known to various hominids that hurling a blunt object was a reasonable way to deliver damage from a distance. Fittingly enough, the worlds of the Purist faction are among the chief manufacturers of mass drivers.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Micro_Driver_ammo",
@@ -489,7 +581,9 @@
         "price": "200",
         "mass": "8",
         "volume": "1",
-        "description": "@upgrades/accelerator_gun.image@Very small, very dense, somewhat cheap, magnetically reactive."
+        "description": "@upgrades/accelerator_gun.image@Very small, very dense, somewhat cheap, magnetically reactive.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Mini_Driver_ammo",
@@ -497,7 +591,9 @@
         "price": "150",
         "mass": "8",
         "volume": "1",
-        "description": "@upgrades/accelerator_gun.image@Small, dense, cheap, magnetically reactive."
+        "description": "@upgrades/accelerator_gun.image@Small, dense, cheap, magnetically reactive.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Hephaestus_Mini",
@@ -505,7 +601,9 @@
         "price": "110000",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/accelerator_gun.image@A scaled down version of the electromagnetic accelerator used in the Hephaestus point defense emplacements, this Andolian death-dealer is special less in its ability to fling its projectiles rapidly and at high velocity than its compatibility with a very particular projectile of Andolian manufacture."
+        "description": "@upgrades/accelerator_gun.image@A scaled down version of the electromagnetic accelerator used in the Hephaestus point defense emplacements, this Andolian death-dealer is special less in its ability to fling its projectiles rapidly and at high velocity than its compatibility with a very particular projectile of Andolian manufacture.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Hephaestus_Mini_ammo",
@@ -513,7 +611,9 @@
         "price": "500",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/swarm.image@The ammunition for the Hephaestus mini-driver is by far one of the smallest and most advanced shield-piercing rounds developed to date."
+        "description": "@upgrades/swarm.image@The ammunition for the Hephaestus mini-driver is by far one of the smallest and most advanced shield-piercing rounds developed to date.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "laser",
@@ -521,7 +621,9 @@
         "price": "3500",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/light.image@Though not a laser by any stretch of the imagination, due to its resemblance to the so called 'lasers' of classic games and movies of the previous millenium, the misnomer has stuck stronger than space rated epoxy. Cheap and utterly dependable, this and other similar low yield exhaust-compression weapons are ubiquitous in armed civilian populations."
+        "description": "@upgrades/light.image@Though not a laser by any stretch of the imagination, due to its resemblance to the so called 'lasers' of classic games and movies of the previous millenium, the misnomer has stuck stronger than space rated epoxy. Cheap and utterly dependable, this and other similar low yield exhaust-compression weapons are ubiquitous in armed civilian populations.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Arc_Device",
@@ -529,7 +631,9 @@
         "price": "6000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam3.image@The trick, as many an unfortunate pirate has learned by experience, is to keep sufficient distance that the disabled enemy vessel is not accidently welded to your own ship. When used on security drones, the welding failure-mode is seen as more of a bonus."
+        "description": "@upgrades/beam3.image@The trick, as many an unfortunate pirate has learned by experience, is to keep sufficient distance that the disabled enemy vessel is not accidently welded to your own ship. When used on security drones, the welding failure-mode is seen as more of a bonus.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "leech_gun",
@@ -537,7 +641,9 @@
         "price": "66000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam2.image@Like the Crippler, the leech gun relies on sophisticated projectiles housing single-shot laser warheads and minimal targeting systems to do the dirty work of rendering a target vessel disabled. Unlike the Crippler, the leech gun has a reputation for being sufficiently underpowered that it's dangerous to not pack more lethal weaponry as well."
+        "description": "@upgrades/beam2.image@Like the Crippler, the leech gun relies on sophisticated projectiles housing single-shot laser warheads and minimal targeting systems to do the dirty work of rendering a target vessel disabled. Unlike the Crippler, the leech gun has a reputation for being sufficiently underpowered that it's dangerous to not pack more lethal weaponry as well.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "crippler",
@@ -545,7 +651,9 @@
         "price": "120000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam2.image@Originally designed for IntelSec and Homeland Security forces, the Crippler has reached increasingly large customer bases in the many decades since its introduction. Most experts believe this to be due to the fact that competitors looking to enter the less-than-lethal weapons market have tended to underestimate how difficult it is to hit appropriate subsystems to render a craft disabled but intact."
+        "description": "@upgrades/beam2.image@Originally designed for IntelSec and Homeland Security forces, the Crippler has reached increasingly large customer bases in the many decades since its introduction. Most experts believe this to be due to the fact that competitors looking to enter the less-than-lethal weapons market have tended to underestimate how difficult it is to hit appropriate subsystems to render a craft disabled but intact.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Plasma_Plume",
@@ -553,7 +661,9 @@
         "price": "500",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/light.image@It's a (plasma) flamethrower! ... in space! If you can actually get close enough to hit anything, the ionization can disable all sort and manner of targetted electrical systems, but the plasma plume's range tends to limit its applications to relatively stationary objects. Cheap as vaccuum, flashy as a nova, and unlikely to cause any real harm, this is a favored weapon of rent-a-cops and parking enforcement officials everywhere. "
+        "description": "@upgrades/light.image@It's a (plasma) flamethrower! ... in space! If you can actually get close enough to hit anything, the ionization can disable all sort and manner of targetted electrical systems, but the plasma plume's range tends to limit its applications to relatively stationary objects. Cheap as vaccuum, flashy as a nova, and unlikely to cause any real harm, this is a favored weapon of rent-a-cops and parking enforcement officials everywhere. ",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Photon_MK_I",
@@ -561,7 +671,9 @@
         "price": "400000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam3.image@The oldest active armament of what would come to be a long series of Aeran PESC (Photon Emission on Shield Collapse) weapons, the gun itself is a non-descript warhead accelerator designed around the MK I PESC ammunition."
+        "description": "@upgrades/beam3.image@The oldest active armament of what would come to be a long series of Aeran PESC (Photon Emission on Shield Collapse) weapons, the gun itself is a non-descript warhead accelerator designed around the MK I PESC ammunition.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Photon_MK_II",
@@ -569,7 +681,9 @@
         "price": "600000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam2.image@A significant improvement with respect to the MK I in both accelerator and warhead, the MK II is a briusing weapon with solid shield penetration still heavily in service across the entire Aeran fleet."
+        "description": "@upgrades/beam2.image@A significant improvement with respect to the MK I in both accelerator and warhead, the MK II is a briusing weapon with solid shield penetration still heavily in service across the entire Aeran fleet.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Photon_MK_III",
@@ -577,7 +691,9 @@
         "price": "400000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/medium.image@A refinement, rather than an improvement over the MK II, the MK III is a smaller weapon based around a much smaller warhead and a faster rate of fire, extending the PESC weaponry to lighter Aeran craft and emplacements."
+        "description": "@upgrades/medium.image@A refinement, rather than an improvement over the MK II, the MK III is a smaller weapon based around a much smaller warhead and a faster rate of fire, extending the PESC weaponry to lighter Aeran craft and emplacements.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "razor_gun",
@@ -585,7 +701,9 @@
         "price": "400000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/razor_gun.image@Sadly enough for their former marketing exectutives, 'Ring around the targets, pocket-size the fuzies, deuterium-deuterium, they all go boom!' did not in fact make for a good advertising campaign."
+        "description": "@upgrades/razor_gun.image@Sadly enough for their former marketing exectutives, 'Ring around the targets, pocket-size the fuzies, deuterium-deuterium, they all go boom!' did not in fact make for a good advertising campaign.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "reaper_cannon",
@@ -593,7 +711,9 @@
         "price": "800000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/beam3.image@The grimmest part of this Reaper is probably the 37 page manual on the appropriate handling of the anti-matter filled rounds. The gun itself, after all, is a rather sporty number."
+        "description": "@upgrades/beam3.image@The grimmest part of this Reaper is probably the 37 page manual on the appropriate handling of the anti-matter filled rounds. The gun itself, after all, is a rather sporty number.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Photon_MK_I_ammo",
@@ -601,7 +721,9 @@
         "price": "4000",
         "mass": "5",
         "volume": "1",
-        "description": "@upgrades/beam3.image@Aeran PESC (Photon Emission on Shield Collapse) Warhead. Essentially consisting of a faulty shield generator in miniature, on contact with any shield or object, the warhead's shield will collapse through the warhead itself, emitting a large number of high-energy photons in the process, thus lending notable shield-penetrating damage. While the root principle has been known to all of the major space-faring groups for some time, only the Aera have pursured significant weaponization."
+        "description": "@upgrades/beam3.image@Aeran PESC (Photon Emission on Shield Collapse) Warhead. Essentially consisting of a faulty shield generator in miniature, on contact with any shield or object, the warhead's shield will collapse through the warhead itself, emitting a large number of high-energy photons in the process, thus lending notable shield-penetrating damage. While the root principle has been known to all of the major space-faring groups for some time, only the Aera have pursured significant weaponization.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Photon_MK_II_ammo",
@@ -609,7 +731,9 @@
         "price": "5000",
         "mass": "5",
         "volume": "1",
-        "description": "@upgrades/beam2.image@Aeran PESC (Photon Emission on Shield Collapse) Warhead. Essentially consisting of a faulty shield generator in miniature, on contact with any shield or object, the warhead's shield will collapse through the warhead itself, emitting a large number of high-energy photons in the process, thus lending notable shield-penetrating damage. While the root principle has been known to all of the major space-faring groups for some time, only the Aera have pursured significant weaponization."
+        "description": "@upgrades/beam2.image@Aeran PESC (Photon Emission on Shield Collapse) Warhead. Essentially consisting of a faulty shield generator in miniature, on contact with any shield or object, the warhead's shield will collapse through the warhead itself, emitting a large number of high-energy photons in the process, thus lending notable shield-penetrating damage. While the root principle has been known to all of the major space-faring groups for some time, only the Aera have pursured significant weaponization.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "Photon_MK_III_ammo",
@@ -617,7 +741,9 @@
         "price": "6000",
         "mass": "5",
         "volume": "1",
-        "description": "@upgrades/medium.image@Aeran PESC (Photon Emission on Shield Collapse) Warhead. Essentially consisting of a faulty shield generator in miniature, on contact with any shield or object, the warhead's shield will collapse through the warhead itself, emitting a large number of high-energy photons in the process, thus lending notable shield-penetrating damage. While the root principle has been known to all of the major space-faring groups for some time, only the Aera have pursured significant weaponization."
+        "description": "@upgrades/medium.image@Aeran PESC (Photon Emission on Shield Collapse) Warhead. Essentially consisting of a faulty shield generator in miniature, on contact with any shield or object, the warhead's shield will collapse through the warhead itself, emitting a large number of high-energy photons in the process, thus lending notable shield-penetrating damage. While the root principle has been known to all of the major space-faring groups for some time, only the Aera have pursured significant weaponization.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "razor_gun_ammo",
@@ -625,7 +751,9 @@
         "price": "4000",
         "mass": "5",
         "volume": "1",
-        "description": "@upgrades/razor_gun.image@Each Razor round is a miniature fusion device, and a real pain to get through customs."
+        "description": "@upgrades/razor_gun.image@Each Razor round is a miniature fusion device, and a real pain to get through customs.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "reaper_cannon_ammo",
@@ -633,7 +761,9 @@
         "price": "6000",
         "mass": "5",
         "volume": "1",
-        "description": "@upgrades/beam3.image@Keeping an anti-matter containment unit intact when being hurled out of a gun at several kilometers per second is no trivial matter, as the pricetag will verify."
+        "description": "@upgrades/beam3.image@Keeping an anti-matter containment unit intact when being hurled out of a gun at several kilometers per second is no trivial matter, as the pricetag will verify.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "hellspawn",
@@ -641,7 +771,9 @@
         "price": "45000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@missile-hud.image@Echewing strong AI, the Rlaan rely on an engineered species derived from something akin to a hunting dog to pilot their drones. Most other species find the idea of giving disembodied pet brains firing control over energy weapons to be mildly disconcerting. The Hellspawn model is one of the smaller Rlaan drones, consisting of little more than two turrets, sensors, and a drive system. Survivability is not a priority, as evidenced by the sizeable self-destruct package."
+        "description": "@missile-hud.image@Echewing strong AI, the Rlaan rely on an engineered species derived from something akin to a hunting dog to pilot their drones. Most other species find the idea of giving disembodied pet brains firing control over energy weapons to be mildly disconcerting. The Hellspawn model is one of the smaller Rlaan drones, consisting of little more than two turrets, sensors, and a drive system. Survivability is not a priority, as evidenced by the sizeable self-destruct package.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "stormfire",
@@ -649,7 +781,9 @@
         "price": "2000",
         "mass": "0.01",
         "volume": "1",
-        "description": "\"@upgrades/swarm.image@While individually fairly worthless, the PC-031 \"\"Stormfire\"\" rounds were designed as a low-yield, low-overhead projectiles that could be rapidly emmitted in high numbers by fighters with multiple weapon mountpoints, or as point defense on capital ships. Surplus Stormfires have seen additional use among merchants as cheap, reliable alternatives to energy weapons. \""
+        "description": "\"@upgrades/swarm.image@While individually fairly worthless, the PC-031 \"\"Stormfire\"\" rounds were designed as a low-yield, low-overhead projectiles that could be rapidly emmitted in high numbers by fighters with multiple weapon mountpoints, or as point defense on capital ships. Surplus Stormfires have seen additional use among merchants as cheap, reliable alternatives to energy weapons. \"",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "antimatter_gun",
@@ -657,7 +791,9 @@
         "price": "720000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/medium.image@As may be expected of a device created to sling anti-matter, any error during the firing process will not merely slag the gun, but may evapourate it and a large portion of the vessel on which it is mounted; thus, every aspect of the process is perfectly controlled and subject to significant redundancy. Needless to say, such engineering does not come cheap."
+        "description": "@upgrades/medium.image@As may be expected of a device created to sling anti-matter, any error during the firing process will not merely slag the gun, but may evapourate it and a large portion of the vessel on which it is mounted; thus, every aspect of the process is perfectly controlled and subject to significant redundancy. Needless to say, such engineering does not come cheap.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "tractor_beam",
@@ -665,7 +801,9 @@
         "price": "7500",
         "mass": "0.01",
         "volume": "1",
-        "description": "@cargo/tractor_beam.image@Gravitic technology can be used in a wide variety of ways: arguably, the most popular is keeping your soup in its bowl. A tractor beam, on the other hand, is good at putting somebody else's soup in your bowl. "
+        "description": "@cargo/tractor_beam.image@Gravitic technology can be used in a wide variety of ways: arguably, the most popular is keeping your soup in its bowl. A tractor beam, on the other hand, is good at putting somebody else's soup in your bowl. ",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "repulsor_beam",
@@ -673,7 +811,9 @@
         "price": "50000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@cargo/repulsor_beam.image@Repulsor beams, relatively new items on the market, have seen considerable use in large-scale construction projects ever since it was discovered how to keep them from mangling the point of contact; some creative combatants have found different uses for them."
+        "description": "@cargo/repulsor_beam.image@Repulsor beams, relatively new items on the market, have seen considerable use in large-scale construction projects ever since it was discovered how to keep them from mangling the point of contact; some creative combatants have found different uses for them.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "tractor_heavy",
@@ -681,7 +821,9 @@
         "price": "27500",
         "mass": "0.01",
         "volume": "1",
-        "description": "@cargo/tractor_heavy.image@Animal magnetism is overrated.  This is just over-engineered. Capable of producing a g-forces that would turn people, elephants, and any appropriately hued fruits into raspberry colored toast topping, heavy tractor beams are rarely seen outside of deepspace construction yards and piracy organizations."
+        "description": "@cargo/tractor_heavy.image@Animal magnetism is overrated.  This is just over-engineered. Capable of producing a g-forces that would turn people, elephants, and any appropriately hued fruits into raspberry colored toast topping, heavy tractor beams are rarely seen outside of deepspace construction yards and piracy organizations.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "tractor_capability",
@@ -689,7 +831,9 @@
         "price": "50000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@cargo/tractor_capability.image@Traditionally, most weapon mounts aren't constructed to handle the strains associated with tractor beam usage. Fortunately, this is usually a cost-cutting measure, and installing the necessary reinforcements doesn't tend to interfere with the weapon mount, although it may void certain warranties. "
+        "description": "@cargo/tractor_capability.image@Traditionally, most weapon mounts aren't constructed to handle the strains associated with tractor beam usage. Fortunately, this is usually a cost-cutting measure, and installing the necessary reinforcements doesn't tend to interfere with the weapon mount, although it may void certain warranties. ",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "autotracking",
@@ -697,17 +841,19 @@
         "price": "100000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/circuit1.image@While all mounted weapons have inherent auto-tracking capabilities, these defaults are limited in civilian mounts. A full-powered military auto-tracker like this greatly enhances weapon accuracy."
+        "description": "@upgrades/circuit1.image@While all mounted weapons have inherent auto-tracking capabilities, these defaults are limited in civilian mounts. A full-powered military auto-tracker like this greatly enhances weapon accuracy.",
+        "upgrade": true,
+        "weapoon": true
     },
-    
-    
     {
         "file": "rlaan_turret_pd",
         "categoryname": "upgrades/Weapons/Turrets/Rlaan",
         "price": "100000",
         "mass": "0.1",
         "volume": "1",
-        "description": "@upgrades/beam1.image@The Rlaan are well known for their disdain of missiles, especially those fired at them."
+        "description": "@upgrades/beam1.image@The Rlaan are well known for their disdain of missiles, especially those fired at them.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "rlaan_turret_mini",
@@ -715,7 +861,9 @@
         "price": "140000",
         "mass": "0.1",
         "volume": "1",
-        "description": "@upgrades/turret_medium.image@While Rlaan ships tend to mount flash-shields capable of shrugging off most small arms fire, they still prefer the option of 'convincing' fighters to stop firing."
+        "description": "@upgrades/turret_medium.image@While Rlaan ships tend to mount flash-shields capable of shrugging off most small arms fire, they still prefer the option of 'convincing' fighters to stop firing.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "aera_turret_pd",
@@ -723,7 +871,9 @@
         "price": "100000",
         "mass": "0.1",
         "volume": "1",
-        "description": "@upgrades/beam1.image@Using low yield pulse lasers, the aera have made simple and effective anti-missile turrets."
+        "description": "@upgrades/beam1.image@Using low yield pulse lasers, the aera have made simple and effective anti-missile turrets.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "beam_turret",
@@ -731,7 +881,9 @@
         "price": "150000",
         "mass": "0.1",
         "volume": "1",
-        "description": "@upgrades/turret_heavy.image@Specially designed for the energy and heat dissipation requirements of beam weapons, this turret has everything you need to mount a pair of them."
+        "description": "@upgrades/turret_heavy.image@Specially designed for the energy and heat dissipation requirements of beam weapons, this turret has everything you need to mount a pair of them.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "turret_pd",
@@ -739,7 +891,9 @@
         "price": "100000",
         "mass": "0.1",
         "volume": "1",
-        "description": "@upgrades/beam3.image@One is heavily advised to not play 'catch the missile' unless one mounts several of these."
+        "description": "@upgrades/beam3.image@One is heavily advised to not play 'catch the missile' unless one mounts several of these.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "heavy_turret",
@@ -747,7 +901,9 @@
         "price": "300000",
         "mass": "0.1",
         "volume": "1",
-        "description": "@upgrades/turret_heavy.image@For when evasive maneuvers are too subtle a hint your tailgaters."
+        "description": "@upgrades/turret_heavy.image@For when evasive maneuvers are too subtle a hint your tailgaters.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "small_turret",
@@ -755,7 +911,9 @@
         "price": "80000",
         "mass": "0.1",
         "volume": "1",
-        "description": "@upgrades/turret_light.image@Given the armament commonly placed in such turrets, the small turret has become affectionately known as 'the machine that goes ping'."
+        "description": "@upgrades/turret_light.image@Given the armament commonly placed in such turrets, the small turret has become affectionately known as 'the machine that goes ping'.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "medium_turret",
@@ -763,7 +921,9 @@
         "price": "250000",
         "mass": "0.1",
         "volume": "1",
-        "description": "@upgrades/turret_medium.image@It turns, it shoots, it slices. No, it does not dice, but it does come with a free fuzzy pair."
+        "description": "@upgrades/turret_medium.image@It turns, it shoots, it slices. No, it does not dice, but it does come with a free fuzzy pair.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "capship_turret",
@@ -771,7 +931,9 @@
         "price": "1600000",
         "mass": "0.1",
         "volume": "1",
-        "description": "@upgrades/razor_gun.image@When hunting for bear, hover softly, and carry a big stick"
+        "description": "@upgrades/razor_gun.image@When hunting for bear, hover softly, and carry a big stick",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "capship_turret_heavy",
@@ -779,7 +941,9 @@
         "price": "8000000",
         "mass": "0.1",
         "volume": "1",
-        "description": "@upgrades/beam2.image@If your vessel can mount this, this can mount whatever you want."
+        "description": "@upgrades/beam2.image@If your vessel can mount this, this can mount whatever you want.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "turret_pd_long",
@@ -787,7 +951,9 @@
         "price": "800000",
         "mass": "0.1",
         "volume": "1",
-        "description": "@upgrades/beam1.image@One of the most impressive applications of disruptor technology, this military rated point defense turret is the best of its kind."
+        "description": "@upgrades/beam1.image@One of the most impressive applications of disruptor technology, this military rated point defense turret is the best of its kind.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "franklin_pd",
@@ -795,17 +961,19 @@
         "price": "600000",
         "mass": "0.1",
         "volume": "1",
-        "description": "@../units/franklin/franklin-hud.image@These turrets were custom designed for the Franklin class diplomatic transport. Any hotshot who splurges on the Franklin should undoubtedly get these fine turrets to complement the exterior decor."
+        "description": "@../units/franklin/franklin-hud.image@These turrets were custom designed for the Franklin class diplomatic transport. Any hotshot who splurges on the Franklin should undoubtedly get these fine turrets to complement the exterior decor.",
+        "upgrade": true,
+        "weapoon": true
     },
-    
-    
     {
         "file": "kineticmissile",
         "categoryname": "upgrades/Ammunition/Capship",
         "price": "4000",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@missile-hud.image@Behold KE=1/2MV^2: large values of M and high values of V yield large numbers of obliterated fragments of intended targets. (Capital sized launch platform sold separately, shield batteries included.)"
+        "description": "@missile-hud.image@Behold KE=1/2MV^2: large values of M and high values of V yield large numbers of obliterated fragments of intended targets. (Capital sized launch platform sold separately, shield batteries included.)",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "capiff_ammo",
@@ -813,7 +981,9 @@
         "price": "2000",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/capiff.image@Drawing upon the greater sensor capability and volumetric resources of a capital vessel, these larger IFF missiles can deliver a larger payload over a much longer intercept sphere than their fighter-launched cousins."
+        "description": "@upgrades/capiff.image@Drawing upon the greater sensor capability and volumetric resources of a capital vessel, these larger IFF missiles can deliver a larger payload over a much longer intercept sphere than their fighter-launched cousins.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "cap_iff",
@@ -821,7 +991,9 @@
         "price": "2000",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/capiff.image@Drawing upon the greater sensor capability and volumetric resources of a capital vessel, these larger IFF missiles can deliver a larger payload over a much longer intercept sphere than their fighter-launched cousins."
+        "description": "@upgrades/capiff.image@Drawing upon the greater sensor capability and volumetric resources of a capital vessel, these larger IFF missiles can deliver a larger payload over a much longer intercept sphere than their fighter-launched cousins.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "capcluster_ammo",
@@ -829,7 +1001,9 @@
         "price": "2000",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/missile.image@Capital ships benefit both from being large enough to launch effective cluster munitions and robust enough to not worry about doorstep detonations."
+        "description": "@upgrades/missile.image@Capital ships benefit both from being large enough to launch effective cluster munitions and robust enough to not worry about doorstep detonations.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "capshipmissile_ammo",
@@ -837,7 +1011,9 @@
         "price": "2000",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/capshipmissile.image@As large as some insystem fighters and sporting the latest in stealth and ECCM technology, these SPEC capable missiles, frequently seen tipped with warheads in the 10 megaton or higher range, can make dropping one's shields to retreat a truly nerve-wracking decision."
+        "description": "@upgrades/capshipmissile.image@As large as some insystem fighters and sporting the latest in stealth and ECCM technology, these SPEC capable missiles, frequently seen tipped with warheads in the 10 megaton or higher range, can make dropping one's shields to retreat a truly nerve-wracking decision.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "grand_gauss",
@@ -845,7 +1021,9 @@
         "price": "3000",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/emp2.image@The spinal mounted armament of the Leonidas class dreadnaughts is something to behold. If the principle behind the massive accelerators is not novel, their scale remains awe-inspiring."
+        "description": "@upgrades/emp2.image@The spinal mounted armament of the Leonidas class dreadnaughts is something to behold. If the principle behind the massive accelerators is not novel, their scale remains awe-inspiring.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "dumbfire_ammo",
@@ -853,7 +1031,9 @@
         "price": "20",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/dumbfire.image@Removing maneuvering jets capable of counteracting a missile's momentum leaves a lot more room for a warhead. Of course, it also makes for a missile that only flies in a straight line."
+        "description": "@upgrades/dumbfire.image@Removing maneuvering jets capable of counteracting a missile's momentum leaves a lot more room for a warhead. Of course, it also makes for a missile that only flies in a straight line.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "heatseeker_ammo",
@@ -861,7 +1041,9 @@
         "price": "35",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/heatseeker.image@A missile which locks onto a heat source -- a ship's engines, for example -- rather than a radar or IFF signal. The Heatseeker is not as vulnerable to ECM as torpedoes, IFF or other guided missiles are. Damage is respectable for their small size. They are also relatively inexpensive and widely available. Most effective against light and medium ships. They are best used in salvos rather than individually. One missile often will weaken the target's defenses enough to let the others get through and do damage to the ship itself. CAUTION: If you are attacking targets near a friendly capship, heat seekers launched at targets within a few hundred meters from the capship may well lock onto the capship instead. That tends to get you talked about by the capship. "
+        "description": "@upgrades/heatseeker.image@A missile which locks onto a heat source -- a ship's engines, for example -- rather than a radar or IFF signal. The Heatseeker is not as vulnerable to ECM as torpedoes, IFF or other guided missiles are. Damage is respectable for their small size. They are also relatively inexpensive and widely available. Most effective against light and medium ships. They are best used in salvos rather than individually. One missile often will weaken the target's defenses enough to let the others get through and do damage to the ship itself. CAUTION: If you are attacking targets near a friendly capship, heat seekers launched at targets within a few hundred meters from the capship may well lock onto the capship instead. That tends to get you talked about by the capship. ",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "image_recognition_ammo",
@@ -869,7 +1051,9 @@
         "price": "75",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/imrec.image@Like an obsessive-compulsive stalker, once it knows what you look like, it's not going to stop showing up at your doorstep."
+        "description": "@upgrades/imrec.image@Like an obsessive-compulsive stalker, once it knows what you look like, it's not going to stop showing up at your doorstep.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "friend_or_foe_ammo",
@@ -877,7 +1061,9 @@
         "price": "100",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/fof.image@There are those who, steadfast in their desire to reduce signals cluttering battlefield communications, have advocated abandoning traditional IFF mechanisms. Fortunately for missile and sensor manufacturers everywhere, such proponents have a remarkable tendency to find their ships hit by IFF missiles."
+        "description": "@upgrades/fof.image@There are those who, steadfast in their desire to reduce signals cluttering battlefield communications, have advocated abandoning traditional IFF mechanisms. Fortunately for missile and sensor manufacturers everywhere, such proponents have a remarkable tendency to find their ships hit by IFF missiles.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "torpedo_ammo",
@@ -885,7 +1071,9 @@
         "price": "2000",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/emp1.image@Featuring bulk and drive style rapidly approaching that of a small vessel, these beasts pack a heavy punch, but tend to have acceleration curves suited to catching only the less than fleet of foot."
+        "description": "@upgrades/emp1.image@Featuring bulk and drive style rapidly approaching that of a small vessel, these beasts pack a heavy punch, but tend to have acceleration curves suited to catching only the less than fleet of foot.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "advtorpedo_ammo",
@@ -893,7 +1081,9 @@
         "price": "2000",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/missile.image@The Aeran equivalent of the Confederation torpedo is just as sluggish, but packs a more vicious punch."
+        "description": "@upgrades/missile.image@The Aeran equivalent of the Confederation torpedo is just as sluggish, but packs a more vicious punch.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "emp_torpedo_ammo",
@@ -901,7 +1091,9 @@
         "price": "2500",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/emp3.image@Employed in increasingly large numbers by regional guard units, EMP torpedos seek to sufficiently damage the electronics of a vessel so as to render it out of user control. Such devices, in the absence of an atmosphere to assist with EMP effects, must be quite large, and have thus been adapted to a torpedo chassis."
+        "description": "@upgrades/emp3.image@Employed in increasingly large numbers by regional guard units, EMP torpedos seek to sufficiently damage the electronics of a vessel so as to render it out of user control. Such devices, in the absence of an atmosphere to assist with EMP effects, must be quite large, and have thus been adapted to a torpedo chassis.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "javelin_ammo",
@@ -909,7 +1101,9 @@
         "price": "4000",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/swarm.image@An older Aeran PESC mini-warhead adapted for rocket pod distribution."
+        "description": "@upgrades/swarm.image@An older Aeran PESC mini-warhead adapted for rocket pod distribution.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "cluster_ammo",
@@ -917,7 +1111,9 @@
         "price": "2000",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/cluster.image@While fighter-mounted cluster missiles are unlikely to actually destroy any vessels, they are extremely useful for getting the attention of several craft in one go."
+        "description": "@upgrades/cluster.image@While fighter-mounted cluster missiles are unlikely to actually destroy any vessels, they are extremely useful for getting the attention of several craft in one go.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "swarm_ammo",
@@ -925,7 +1121,9 @@
         "price": "80",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/swarm.image@If you love the smell of Katyushas in the morning, then you probably already have one of these."
+        "description": "@upgrades/swarm.image@If you love the smell of Katyushas in the morning, then you probably already have one of these.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "photon_swarm_ammo",
@@ -933,7 +1131,9 @@
         "price": "90",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/swarm.image@A more recently developed Aeran PESC mini-warhead, photon swarm rocket pods are extremely common on Aeran light craft."
+        "description": "@upgrades/swarm.image@A more recently developed Aeran PESC mini-warhead, photon swarm rocket pods are extremely common on Aeran light craft.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "killer_bee_ammo",
@@ -941,7 +1141,9 @@
         "price": "85",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/swarm.image@Like their namesake, one sting won't hurt too much, but nobody fires just one of these."
+        "description": "@upgrades/swarm.image@Like their namesake, one sting won't hurt too much, but nobody fires just one of these.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "hail_ammo",
@@ -949,7 +1151,9 @@
         "price": "90",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/swarm.image@Sometimes it rains, sometimes it hails, but when you're armed with Hail emplacents, it rains death from above."
+        "description": "@upgrades/swarm.image@Sometimes it rains, sometimes it hails, but when you're armed with Hail emplacents, it rains death from above.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "breeze_ammo",
@@ -957,7 +1161,9 @@
         "price": "300",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/missile.image@An otherwise unremarkable missile with an odd aspect ratio."
+        "description": "@upgrades/missile.image@An otherwise unremarkable missile with an odd aspect ratio.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "porcupine_mine_ammo",
@@ -965,7 +1171,9 @@
         "price": "300",
         "mass": "0.01",
         "volume": "0.1",
-        "description": "@upgrades/porcupine_mine.image@Dropped by Aeran mine-layers and, in smaller numbers, other small craft, these mines each mount a single gun with a limited number of rounds. Once ammunition or energy is depleted, the mines self-destruct. These mines are used in both defensive emplacements and as a harassing distraction against pursuing craft."
+        "description": "@upgrades/porcupine_mine.image@Dropped by Aeran mine-layers and, in smaller numbers, other small craft, these mines each mount a single gun with a limited number of rounds. Once ammunition or energy is depleted, the mines self-destruct. These mines are used in both defensive emplacements and as a harassing distraction against pursuing craft.",
+        "upgrade": true,
+        "weapoon": true
     },
     {
         "file": "leech_ammo",
@@ -973,17 +1181,18 @@
         "price": "1000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/leech.image@Complicated rounds with sensors and one-shot lasers designed to disable, not destroy, enemy craft."
+        "description": "@upgrades/leech.image@Complicated rounds with sensors and one-shot lasers designed to disable, not destroy, enemy craft.",
+        "upgrade": true,
+        "weapoon": true
     },
-    
-    
     {
         "file": "cloaking_device",
         "categoryname": "upgrades/Experimental",
         "price": "259000",
         "mass": "8.9",
         "volume": "1",
-        "description": "@cargo/cloaking_device_experimental.image@This device uses gravity manipulation technology. A powerful gravitational lens distorts a massive region around the vessel, bending signals emitted by active sensors around the ship and out at seeming random angles and locations. This makes it very easy to know that a ship mounting a cloaking device is present, but very hard to figure out what class of ship, where it's headed, and where exactly it is."
+        "description": "@cargo/cloaking_device_experimental.image@This device uses gravity manipulation technology. A powerful gravitational lens distorts a massive region around the vessel, bending signals emitted by active sensors around the ship and out at seeming random angles and locations. This makes it very easy to know that a ship mounting a cloaking device is present, but very hard to figure out what class of ship, where it's headed, and where exactly it is.",
+        "upgrade": true
     },
     {
         "file": "capacitor01",
@@ -991,7 +1200,8 @@
         "price": "500",
         "mass": "2",
         "volume": "2",
-        "description": "@upgrades/capacitor.image@Energy storage."
+        "description": "@upgrades/capacitor.image@Energy storage.",
+        "upgrade": true
     },
     {
         "file": "capacitor02",
@@ -999,7 +1209,8 @@
         "price": "1000",
         "mass": "4",
         "volume": "4",
-        "description": "@upgrades/capacitor.image@Energy storage."
+        "description": "@upgrades/capacitor.image@Energy storage.",
+        "upgrade": true
     },
     {
         "file": "capacitor03",
@@ -1007,7 +1218,8 @@
         "price": "2000",
         "mass": "6",
         "volume": "6",
-        "description": "@upgrades/capacitor.image@Energy storage."
+        "description": "@upgrades/capacitor.image@Energy storage.",
+        "upgrade": true
     },
     {
         "file": "capacitor04",
@@ -1015,7 +1227,8 @@
         "price": "4000",
         "mass": "8",
         "volume": "8",
-        "description": "@upgrades/capacitor2.image@Energy storage."
+        "description": "@upgrades/capacitor2.image@Energy storage.",
+        "upgrade": true
     },
     {
         "file": "capacitor05",
@@ -1023,7 +1236,8 @@
         "price": "8000",
         "mass": "10",
         "volume": "10",
-        "description": "@upgrades/capacitor2.image@Energy storage."
+        "description": "@upgrades/capacitor2.image@Energy storage.",
+        "upgrade": true
     },
     {
         "file": "capacitor06",
@@ -1031,7 +1245,8 @@
         "price": "16000",
         "mass": "12",
         "volume": "12",
-        "description": "@upgrades/capacitor2.image@Energy storage."
+        "description": "@upgrades/capacitor2.image@Energy storage.",
+        "upgrade": true
     },
     {
         "file": "capacitor07",
@@ -1039,7 +1254,8 @@
         "price": "32000",
         "mass": "14",
         "volume": "14",
-        "description": "@upgrades/capacitor3.image@Energy storage."
+        "description": "@upgrades/capacitor3.image@Energy storage.",
+        "upgrade": true
     },
     {
         "file": "capacitor08",
@@ -1047,7 +1263,8 @@
         "price": "64000",
         "mass": "16",
         "volume": "16",
-        "description": "@upgrades/capacitor3.image@Energy storage."
+        "description": "@upgrades/capacitor3.image@Energy storage.",
+        "upgrade": true
     },
     {
         "file": "capacitor09",
@@ -1055,7 +1272,8 @@
         "price": "128000",
         "mass": "18",
         "volume": "18",
-        "description": "@upgrades/capacitor3.image@Energy storage."
+        "description": "@upgrades/capacitor3.image@Energy storage.",
+        "upgrade": true
     },
     {
         "file": "capacitor10",
@@ -1063,7 +1281,8 @@
         "price": "256000",
         "mass": "20",
         "volume": "20",
-        "description": "@upgrades/capacitor4.image@Energy storage."
+        "description": "@upgrades/capacitor4.image@Energy storage.",
+        "upgrade": true
     },
     {
         "file": "capacitor11",
@@ -1071,7 +1290,8 @@
         "price": "512000",
         "mass": "22",
         "volume": "22",
-        "description": "@upgrades/capacitor4.image@Energy storage."
+        "description": "@upgrades/capacitor4.image@Energy storage.",
+        "upgrade": true
     },
     {
         "file": "capacitor12",
@@ -1079,7 +1299,8 @@
         "price": "1024000",
         "mass": "24",
         "volume": "24",
-        "description": "@upgrades/capacitor4.image@Energy storage."
+        "description": "@upgrades/capacitor4.image@Energy storage.",
+        "upgrade": true
     },
     {
         "file": "capacitor13",
@@ -1087,7 +1308,8 @@
         "price": "2048000",
         "mass": "26",
         "volume": "26",
-        "description": "@upgrades/capacitor5.image@Energy storage."
+        "description": "@upgrades/capacitor5.image@Energy storage.",
+        "upgrade": true
     },
     {
         "file": "capacitor14",
@@ -1095,7 +1317,8 @@
         "price": "4096000",
         "mass": "28",
         "volume": "28",
-        "description": "@upgrades/capacitor5.image@Energy storage."
+        "description": "@upgrades/capacitor5.image@Energy storage.",
+        "upgrade": true
     },
     {
         "file": "capacitor15",
@@ -1103,7 +1326,8 @@
         "price": "8192000",
         "mass": "30",
         "volume": "30",
-        "description": "@upgrades/capacitor5.image@Energy storage."
+        "description": "@upgrades/capacitor5.image@Energy storage.",
+        "upgrade": true
     },
     {
         "file": "reactor01",
@@ -1111,7 +1335,8 @@
         "price": "500",
         "mass": "1",
         "volume": "2",
-        "description": "@upgrades/reactor.image@Energy production, the friendly fusion way."
+        "description": "@upgrades/reactor.image@Energy production, the friendly fusion way.",
+        "upgrade": true
     },
     {
         "file": "reactor02",
@@ -1119,7 +1344,8 @@
         "price": "1000",
         "mass": "2",
         "volume": "3.5",
-        "description": "@upgrades/reactor.image@Energy production, the friendly fusion way."
+        "description": "@upgrades/reactor.image@Energy production, the friendly fusion way.",
+        "upgrade": true
     },
     {
         "file": "reactor03",
@@ -1127,7 +1353,8 @@
         "price": "2000",
         "mass": "3",
         "volume": "6",
-        "description": "@upgrades/reactor.image@Energy production, the friendly fusion way."
+        "description": "@upgrades/reactor.image@Energy production, the friendly fusion way.",
+        "upgrade": true
     },
     {
         "file": "reactor04",
@@ -1135,7 +1362,8 @@
         "price": "4000",
         "mass": "4",
         "volume": "11",
-        "description": "@upgrades/reactor.image@Energy production, the friendly fusion way."
+        "description": "@upgrades/reactor.image@Energy production, the friendly fusion way.",
+        "upgrade": true
     },
     {
         "file": "reactor05",
@@ -1143,7 +1371,8 @@
         "price": "8000",
         "mass": "5",
         "volume": "18",
-        "description": "@upgrades/reactor2.image@Energy production, the friendly fusion way."
+        "description": "@upgrades/reactor2.image@Energy production, the friendly fusion way.",
+        "upgrade": true
     },
     {
         "file": "reactor06",
@@ -1151,7 +1380,8 @@
         "price": "16000",
         "mass": "6",
         "volume": "32",
-        "description": "@upgrades/reactor2.image@Energy production, the friendly fusion way."
+        "description": "@upgrades/reactor2.image@Energy production, the friendly fusion way.",
+        "upgrade": true
     },
     {
         "file": "reactor07",
@@ -1159,7 +1389,8 @@
         "price": "32000",
         "mass": "7",
         "volume": "60",
-        "description": "@upgrades/reactor2.image@Energy production, the friendly fusion way."
+        "description": "@upgrades/reactor2.image@Energy production, the friendly fusion way.",
+        "upgrade": true
     },
     {
         "file": "reactor08",
@@ -1167,7 +1398,8 @@
         "price": "64000",
         "mass": "8",
         "volume": "100",
-        "description": "@upgrades/reactor2.image@Energy production, the friendly fusion way."
+        "description": "@upgrades/reactor2.image@Energy production, the friendly fusion way.",
+        "upgrade": true
     },
     {
         "file": "reactor09",
@@ -1175,7 +1407,8 @@
         "price": "128000",
         "mass": "9",
         "volume": "175",
-        "description": "@upgrades/reactor3.image@Energy production, the friendly fusion way."
+        "description": "@upgrades/reactor3.image@Energy production, the friendly fusion way.",
+        "upgrade": true
     },
     {
         "file": "reactor10",
@@ -1183,7 +1416,8 @@
         "price": "256000",
         "mass": "10",
         "volume": "310",
-        "description": "@upgrades/reactor3.image@Energy production, the friendly fusion way."
+        "description": "@upgrades/reactor3.image@Energy production, the friendly fusion way.",
+        "upgrade": true
     },
     {
         "file": "reactor11",
@@ -1191,7 +1425,8 @@
         "price": "512000",
         "mass": "12",
         "volume": "540",
-        "description": "@upgrades/reactor3.image@Energy production, the friendly fusion way."
+        "description": "@upgrades/reactor3.image@Energy production, the friendly fusion way.",
+        "upgrade": true
     },
     {
         "file": "reactor12",
@@ -1199,7 +1434,8 @@
         "price": "1024000",
         "mass": "14",
         "volume": "950",
-        "description": "@upgrades/reactor3.image@Energy production, the friendly fusion way."
+        "description": "@upgrades/reactor3.image@Energy production, the friendly fusion way.",
+        "upgrade": true
     },
     {
         "file": "reactor13",
@@ -1207,7 +1443,8 @@
         "price": "2048000",
         "mass": "16",
         "volume": "1650",
-        "description": "@upgrades/reactor4.image@Energy production, the friendly fusion way."
+        "description": "@upgrades/reactor4.image@Energy production, the friendly fusion way.",
+        "upgrade": true
     },
     {
         "file": "reactor14",
@@ -1215,7 +1452,8 @@
         "price": "4096000",
         "mass": "20",
         "volume": "2890",
-        "description": "@upgrades/reactor4.image@Energy production, the friendly fusion way."
+        "description": "@upgrades/reactor4.image@Energy production, the friendly fusion way.",
+        "upgrade": true
     },
     {
         "file": "reactor15",
@@ -1223,7 +1461,8 @@
         "price": "8192000",
         "mass": "24",
         "volume": "5050",
-        "description": "@upgrades/reactor4.image@Energy production, the friendly fusion way."
+        "description": "@upgrades/reactor4.image@Energy production, the friendly fusion way.",
+        "upgrade": true
     },
     {
         "file": "dualshield01",
@@ -1231,7 +1470,8 @@
         "price": "250",
         "mass": "0.5",
         "volume": "2",
-        "description": "@upgrades/shield2light.image@GEM shielding, with fore and aft decoupling."
+        "description": "@upgrades/shield2light.image@GEM shielding, with fore and aft decoupling.",
+        "upgrade": true
     },
     {
         "file": "dualshield02",
@@ -1239,7 +1479,8 @@
         "price": "500",
         "mass": "1",
         "volume": "5",
-        "description": "@upgrades/shield2light.image@GEM shielding, with fore and aft decoupling."
+        "description": "@upgrades/shield2light.image@GEM shielding, with fore and aft decoupling.",
+        "upgrade": true
     },
     {
         "file": "dualshield03",
@@ -1247,7 +1488,8 @@
         "price": "1000",
         "mass": "1.5",
         "volume": "8",
-        "description": "@upgrades/shield4light.image@GEM shielding, with fore and aft decoupling."
+        "description": "@upgrades/shield4light.image@GEM shielding, with fore and aft decoupling.",
+        "upgrade": true
     },
     {
         "file": "dualshield04",
@@ -1255,7 +1497,8 @@
         "price": "2000",
         "mass": "2",
         "volume": "12",
-        "description": "@upgrades/shield4light.image@GEM shielding, with fore and aft decoupling."
+        "description": "@upgrades/shield4light.image@GEM shielding, with fore and aft decoupling.",
+        "upgrade": true
     },
     {
         "file": "dualshield05",
@@ -1263,7 +1506,8 @@
         "price": "4000",
         "mass": "2.5",
         "volume": "16",
-        "description": "@upgrades/shield4light.image@GEM shielding, with fore and aft decoupling."
+        "description": "@upgrades/shield4light.image@GEM shielding, with fore and aft decoupling.",
+        "upgrade": true
     },
     {
         "file": "dualshield06",
@@ -1271,7 +1515,8 @@
         "price": "8000",
         "mass": "3",
         "volume": "21",
-        "description": "@upgrades/shield2medium.image@GEM shielding, with fore and aft decoupling."
+        "description": "@upgrades/shield2medium.image@GEM shielding, with fore and aft decoupling.",
+        "upgrade": true
     },
     {
         "file": "dualshield07",
@@ -1279,7 +1524,8 @@
         "price": "16000",
         "mass": "3.5",
         "volume": "25",
-        "description": "@upgrades/shield2medium.image@GEM shielding, with fore and aft decoupling."
+        "description": "@upgrades/shield2medium.image@GEM shielding, with fore and aft decoupling.",
+        "upgrade": true
     },
     {
         "file": "dualshield08",
@@ -1287,7 +1533,8 @@
         "price": "32000",
         "mass": "4",
         "volume": "30",
-        "description": "@upgrades/shield4medium.image@GEM shielding, with fore and aft decoupling."
+        "description": "@upgrades/shield4medium.image@GEM shielding, with fore and aft decoupling.",
+        "upgrade": true
     },
     {
         "file": "dualshield09",
@@ -1295,7 +1542,8 @@
         "price": "64000",
         "mass": "4.5",
         "volume": "35",
-        "description": "@upgrades/shield4medium.image@GEM shielding, with fore and aft decoupling."
+        "description": "@upgrades/shield4medium.image@GEM shielding, with fore and aft decoupling.",
+        "upgrade": true
     },
     {
         "file": "dualshield10",
@@ -1303,7 +1551,8 @@
         "price": "128000",
         "mass": "5",
         "volume": "40",
-        "description": "@upgrades/shield4medium.image@GEM shielding, with fore and aft decoupling."
+        "description": "@upgrades/shield4medium.image@GEM shielding, with fore and aft decoupling.",
+        "upgrade": true
     },
     {
         "file": "dualshield11",
@@ -1311,7 +1560,8 @@
         "price": "256000",
         "mass": "6",
         "volume": "46",
-        "description": "@upgrades/shield2heavy.image@GEM shielding, with fore and aft decoupling."
+        "description": "@upgrades/shield2heavy.image@GEM shielding, with fore and aft decoupling.",
+        "upgrade": true
     },
     {
         "file": "dualshield12",
@@ -1319,7 +1569,8 @@
         "price": "512000",
         "mass": "7",
         "volume": "52",
-        "description": "@upgrades/shield2heavy.image@GEM shielding, with fore and aft decoupling."
+        "description": "@upgrades/shield2heavy.image@GEM shielding, with fore and aft decoupling.",
+        "upgrade": true
     },
     {
         "file": "dualshield13",
@@ -1327,7 +1578,8 @@
         "price": "1024000",
         "mass": "8",
         "volume": "57",
-        "description": "@upgrades/shield4heavy.image@GEM shielding, with fore and aft decoupling."
+        "description": "@upgrades/shield4heavy.image@GEM shielding, with fore and aft decoupling.",
+        "upgrade": true
     },
     {
         "file": "dualshield14",
@@ -1335,7 +1587,8 @@
         "price": "2048000",
         "mass": "9",
         "volume": "63",
-        "description": "@upgrades/shield4heavy.image@GEM shielding, with fore and aft decoupling."
+        "description": "@upgrades/shield4heavy.image@GEM shielding, with fore and aft decoupling.",
+        "upgrade": true
     },
     {
         "file": "dualshield15",
@@ -1343,7 +1596,8 @@
         "price": "4096000",
         "mass": "10",
         "volume": "70",
-        "description": "@upgrades/shield4heavy.image@GEM shielding, with fore and aft decoupling."
+        "description": "@upgrades/shield4heavy.image@GEM shielding, with fore and aft decoupling.",
+        "upgrade": true
     },
     {
         "file": "quadshield01",
@@ -1351,7 +1605,8 @@
         "price": "500",
         "mass": "1",
         "volume": "4",
-        "description": "@upgrades/shield.image@GEM shielding, fore, aft, port, and starboard decoupling."
+        "description": "@upgrades/shield.image@GEM shielding, fore, aft, port, and starboard decoupling.",
+        "upgrade": true
     },
     {
         "file": "quadshield02",
@@ -1359,7 +1614,8 @@
         "price": "1000",
         "mass": "2",
         "volume": "8",
-        "description": "@upgrades/shield.image@GEM shielding, fore, aft, port, and starboard decoupling."
+        "description": "@upgrades/shield.image@GEM shielding, fore, aft, port, and starboard decoupling.",
+        "upgrade": true
     },
     {
         "file": "quadshield03",
@@ -1367,7 +1623,8 @@
         "price": "2000",
         "mass": "3",
         "volume": "13",
-        "description": "@upgrades/shield.image@GEM shielding, fore, aft, port, and starboard decoupling."
+        "description": "@upgrades/shield.image@GEM shielding, fore, aft, port, and starboard decoupling.",
+        "upgrade": true
     },
     {
         "file": "quadshield04",
@@ -1375,7 +1632,8 @@
         "price": "4000",
         "mass": "4",
         "volume": "18",
-        "description": "@upgrades/shield2.image@GEM shielding, fore, aft, port, and starboard decoupling."
+        "description": "@upgrades/shield2.image@GEM shielding, fore, aft, port, and starboard decoupling.",
+        "upgrade": true
     },
     {
         "file": "quadshield05",
@@ -1383,7 +1641,8 @@
         "price": "8000",
         "mass": "5",
         "volume": "24",
-        "description": "@upgrades/shield2.image@GEM shielding, fore, aft, port, and starboard decoupling."
+        "description": "@upgrades/shield2.image@GEM shielding, fore, aft, port, and starboard decoupling.",
+        "upgrade": true
     },
     {
         "file": "quadshield06",
@@ -1391,7 +1650,8 @@
         "price": "16000",
         "mass": "6",
         "volume": "31",
-        "description": "@upgrades/shield2.image@GEM shielding, fore, aft, port, and starboard decoupling."
+        "description": "@upgrades/shield2.image@GEM shielding, fore, aft, port, and starboard decoupling.",
+        "upgrade": true
     },
     {
         "file": "quadshield07",
@@ -1399,7 +1659,8 @@
         "price": "32000",
         "mass": "7",
         "volume": "38",
-        "description": "@upgrades/shield3.image@GEM shielding, fore, aft, port, and starboard decoupling."
+        "description": "@upgrades/shield3.image@GEM shielding, fore, aft, port, and starboard decoupling.",
+        "upgrade": true
     },
     {
         "file": "quadshield08",
@@ -1407,7 +1668,8 @@
         "price": "64000",
         "mass": "8",
         "volume": "45",
-        "description": "@upgrades/shield3.image@GEM shielding, fore, aft, port, and starboard decoupling."
+        "description": "@upgrades/shield3.image@GEM shielding, fore, aft, port, and starboard decoupling.",
+        "upgrade": true
     },
     {
         "file": "quadshield09",
@@ -1415,7 +1677,8 @@
         "price": "128000",
         "mass": "9",
         "volume": "53",
-        "description": "@upgrades/shield3.image@GEM shielding, fore, aft, port, and starboard decoupling."
+        "description": "@upgrades/shield3.image@GEM shielding, fore, aft, port, and starboard decoupling.",
+        "upgrade": true
     },
     {
         "file": "quadshield10",
@@ -1423,7 +1686,8 @@
         "price": "256000",
         "mass": "10",
         "volume": "61",
-        "description": "@upgrades/shield4.image@GEM shielding, fore, aft, port, and starboard decoupling."
+        "description": "@upgrades/shield4.image@GEM shielding, fore, aft, port, and starboard decoupling.",
+        "upgrade": true
     },
     {
         "file": "quadshield11",
@@ -1431,7 +1695,8 @@
         "price": "512000",
         "mass": "11",
         "volume": "69",
-        "description": "@upgrades/shield4.image@GEM shielding, fore, aft, port, and starboard decoupling."
+        "description": "@upgrades/shield4.image@GEM shielding, fore, aft, port, and starboard decoupling.",
+        "upgrade": true
     },
     {
         "file": "quadshield12",
@@ -1439,7 +1704,8 @@
         "price": "1024000",
         "mass": "12",
         "volume": "78",
-        "description": "@upgrades/shield4.image@GEM shielding, fore, aft, port, and starboard decoupling."
+        "description": "@upgrades/shield4.image@GEM shielding, fore, aft, port, and starboard decoupling.",
+        "upgrade": true
     },
     {
         "file": "quadshield13",
@@ -1447,7 +1713,8 @@
         "price": "2048000",
         "mass": "13",
         "volume": "86",
-        "description": "@upgrades/shield5.image@GEM shielding, fore, aft, port, and starboard decoupling."
+        "description": "@upgrades/shield5.image@GEM shielding, fore, aft, port, and starboard decoupling.",
+        "upgrade": true
     },
     {
         "file": "quadshield14",
@@ -1455,7 +1722,8 @@
         "price": "4096000",
         "mass": "14",
         "volume": "95",
-        "description": "@upgrades/shield5.image@GEM shielding, fore, aft, port, and starboard decoupling."
+        "description": "@upgrades/shield5.image@GEM shielding, fore, aft, port, and starboard decoupling.",
+        "upgrade": true
     },
     {
         "file": "quadshield15",
@@ -1463,7 +1731,8 @@
         "price": "8192000",
         "mass": "15",
         "volume": "104",
-        "description": "@upgrades/shield5.image@GEM shielding, fore, aft, port, and starboard decoupling."
+        "description": "@upgrades/shield5.image@GEM shielding, fore, aft, port, and starboard decoupling.",
+        "upgrade": true
     },
     {
         "file": "mult_overdrive01",
@@ -1471,7 +1740,8 @@
         "price": "4000",
         "mass": "1",
         "volume": "1",
-        "description": "@upgrades/afterburner_generic.image@Engine overdrive. Increases thrust at the expense of decreased fuel efficiency. Comes bundled with appropriate vector-governor firmware updates."
+        "description": "@upgrades/afterburner_generic.image@Engine overdrive. Increases thrust at the expense of decreased fuel efficiency. Comes bundled with appropriate vector-governor firmware updates.",
+        "upgrade": true
     },
     {
         "file": "mult_overdrive02",
@@ -1479,7 +1749,8 @@
         "price": "8000",
         "mass": "2",
         "volume": "2",
-        "description": "@upgrades/afterburner_generic.image@Engine overdrive. Increases thrust at the expense of decreased fuel efficiency. Comes bundled with appropriate vector-governor firmware updates."
+        "description": "@upgrades/afterburner_generic.image@Engine overdrive. Increases thrust at the expense of decreased fuel efficiency. Comes bundled with appropriate vector-governor firmware updates.",
+        "upgrade": true
     },
     {
         "file": "mult_overdrive03",
@@ -1487,7 +1758,8 @@
         "price": "16000",
         "mass": "4",
         "volume": "4",
-        "description": "@upgrades/afterburner_generic.image@Engine overdrive. Increases thrust at the expense of decreased fuel efficiency. Comes bundled with appropriate vector-governor firmware updates."
+        "description": "@upgrades/afterburner_generic.image@Engine overdrive. Increases thrust at the expense of decreased fuel efficiency. Comes bundled with appropriate vector-governor firmware updates.",
+        "upgrade": true
     },
     {
         "file": "mult_overdrive04",
@@ -1495,7 +1767,8 @@
         "price": "32000",
         "mass": "8",
         "volume": "8",
-        "description": "@upgrades/afterburner.image@Engine overdrive. Increases thrust at the expense of decreased fuel efficiency. Comes bundled with appropriate vector-governor firmware updates."
+        "description": "@upgrades/afterburner.image@Engine overdrive. Increases thrust at the expense of decreased fuel efficiency. Comes bundled with appropriate vector-governor firmware updates.",
+        "upgrade": true
     },
     {
         "file": "mult_overdrive05",
@@ -1503,7 +1776,8 @@
         "price": "64000",
         "mass": "12",
         "volume": "12",
-        "description": "@upgrades/afterburner.image@Engine overdrive. Increases thrust at the expense of decreased fuel efficiency. Comes bundled with appropriate vector-governor firmware updates."
+        "description": "@upgrades/afterburner.image@Engine overdrive. Increases thrust at the expense of decreased fuel efficiency. Comes bundled with appropriate vector-governor firmware updates.",
+        "upgrade": true
     },
     {
         "file": "mult_overdrive06",
@@ -1511,7 +1785,8 @@
         "price": "128000",
         "mass": "18",
         "volume": "18",
-        "description": "@upgrades/afterburner.image@Engine overdrive. Increases thrust at the expense of decreased fuel efficiency. Comes bundled with appropriate vector-governor firmware updates."
+        "description": "@upgrades/afterburner.image@Engine overdrive. Increases thrust at the expense of decreased fuel efficiency. Comes bundled with appropriate vector-governor firmware updates.",
+        "upgrade": true
     },
     {
         "file": "jump_drive",
@@ -1519,7 +1794,8 @@
         "price": "8000",
         "mass": "16",
         "volume": "2",
-        "description": "@upgrades/jump_drive.image@A jump drive is required for rapid interstellar travel via the jump network."
+        "description": "@upgrades/jump_drive.image@A jump drive is required for rapid interstellar travel via the jump network.",
+        "upgrade": true
     },
     {
         "file": "add_spec_capacitor01",
@@ -1527,7 +1803,8 @@
         "price": "6000",
         "mass": "5",
         "volume": "4",
-        "description": "@upgrades/reactor_capacitance.image@Capacitor for storing energy for FTL travel"
+        "description": "@upgrades/reactor_capacitance.image@Capacitor for storing energy for FTL travel",
+        "upgrade": true
     },
     {
         "file": "add_spec_capacitor02",
@@ -1535,7 +1812,8 @@
         "price": "18000",
         "mass": "10",
         "volume": "6",
-        "description": "@upgrades/reactor_capacitance.image@Capacitor for storing energy for FTL travel"
+        "description": "@upgrades/reactor_capacitance.image@Capacitor for storing energy for FTL travel",
+        "upgrade": true
     },
     {
         "file": "add_spec_capacitor03",
@@ -1543,7 +1821,8 @@
         "price": "32000",
         "mass": "20",
         "volume": "12",
-        "description": "@upgrades/reactor_capacitance.image@Capacitor for storing energy for FTL travel"
+        "description": "@upgrades/reactor_capacitance.image@Capacitor for storing energy for FTL travel",
+        "upgrade": true
     },
     {
         "file": "add_spec_capacitor04",
@@ -1551,7 +1830,8 @@
         "price": "96000",
         "mass": "40",
         "volume": "18",
-        "description": "@upgrades/reactor_capacitance.image@Capacitor for storing energy for FTL travel"
+        "description": "@upgrades/reactor_capacitance.image@Capacitor for storing energy for FTL travel",
+        "upgrade": true
     },
     {
         "file": "add_spec_capacitor05",
@@ -1559,7 +1839,8 @@
         "price": "150000",
         "mass": "60",
         "volume": "24",
-        "description": "@upgrades/reactor_capacitance.image@Capacitor for storing energy for FTL travel"
+        "description": "@upgrades/reactor_capacitance.image@Capacitor for storing energy for FTL travel",
+        "upgrade": true
     },
     {
         "file": "armor01",
@@ -1567,7 +1848,8 @@
         "price": "4000",
         "mass": "20",
         "volume": "0",
-        "description": "@cargo/plasteel.image@Armor takes up no upgrade volume, but does add to the mass of your ship, affecting maneuverability"
+        "description": "@cargo/plasteel.image@Armor takes up no upgrade volume, but does add to the mass of your ship, affecting maneuverability",
+        "upgrade": true
     },
     {
         "file": "armor02",
@@ -1575,7 +1857,8 @@
         "price": "8000",
         "mass": "25",
         "volume": "0",
-        "description": "@cargo/isometal.image@Armor takes up no upgrade volume, but does add to the mass of your ship, affecting maneuverability"
+        "description": "@cargo/isometal.image@Armor takes up no upgrade volume, but does add to the mass of your ship, affecting maneuverability",
+        "upgrade": true
     },
     {
         "file": "armor03",
@@ -1583,7 +1866,8 @@
         "price": "16000",
         "mass": "30",
         "volume": "0",
-        "description": "@cargo/hull_patches.image@Armor takes up no upgrade volume, but does add to the mass of your ship, affecting maneuverability"
+        "description": "@cargo/hull_patches.image@Armor takes up no upgrade volume, but does add to the mass of your ship, affecting maneuverability",
+        "upgrade": true
     },
     {
         "file": "armor04",
@@ -1591,7 +1875,8 @@
         "price": "32000",
         "mass": "25",
         "volume": "0",
-        "description": "@cargo/tritanium.image@Armor takes up no upgrade volume, but does add to the mass of your ship, affecting maneuverability"
+        "description": "@cargo/tritanium.image@Armor takes up no upgrade volume, but does add to the mass of your ship, affecting maneuverability",
+        "upgrade": true
     },
     {
         "file": "armor05",
@@ -1599,7 +1884,8 @@
         "price": "64000",
         "mass": "20",
         "volume": "0",
-        "description": "@cargo/carbonium.image@Armor takes up no upgrade volume, but does add to the mass of your ship, affecting maneuverability"
+        "description": "@cargo/carbonium.image@Armor takes up no upgrade volume, but does add to the mass of your ship, affecting maneuverability",
+        "upgrade": true
     },
     {
         "file": "armor06",
@@ -1607,7 +1893,8 @@
         "price": "128000",
         "mass": "15",
         "volume": "0",
-        "description": "@cargo/duranium.image@Armor takes up no upgrade volume, but does add to the mass of your ship, affecting maneuverability"
+        "description": "@cargo/duranium.image@Armor takes up no upgrade volume, but does add to the mass of your ship, affecting maneuverability",
+        "upgrade": true
     },
     {
         "file": "Reinforced_Cockpit",
@@ -1615,7 +1902,8 @@
         "price": "4000",
         "mass": "2",
         "volume": "3",
-        "description": "@cargo/plasteel.image@Sometimes, that extra layer of protection is the difference between escape pod launch and inescapable coffin."
+        "description": "@cargo/plasteel.image@Sometimes, that extra layer of protection is the difference between escape pod launch and inescapable coffin.",
+        "upgrade": true
     },
     {
         "file": "skyscope1",
@@ -1623,7 +1911,8 @@
         "price": "500",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/skyscope_alpha.image@With its light weight, the SkyScope is particularly well-suited for the peaceful merchant."
+        "description": "@upgrades/skyscope_alpha.image@With its light weight, the SkyScope is particularly well-suited for the peaceful merchant.",
+        "upgrade": true
     },
     {
         "file": "skyscope2",
@@ -1631,7 +1920,8 @@
         "price": "1000",
         "mass": "0.01",
         "volume": "2",
-        "description": "@upgrades/skyscope_alphaplus.image@With its light weight, the SkyScope is particularly well-suited for the peaceful merchant."
+        "description": "@upgrades/skyscope_alphaplus.image@With its light weight, the SkyScope is particularly well-suited for the peaceful merchant.",
+        "upgrade": true
     },
     {
         "file": "skyscope3",
@@ -1639,7 +1929,8 @@
         "price": "2000",
         "mass": "0.01",
         "volume": "3",
-        "description": "@upgrades/skyscope_beta.image@With its light weight, the SkyScope is particularly well-suited for the peaceful merchant."
+        "description": "@upgrades/skyscope_beta.image@With its light weight, the SkyScope is particularly well-suited for the peaceful merchant.",
+        "upgrade": true
     },
     {
         "file": "starscanner1",
@@ -1647,7 +1938,8 @@
         "price": "4000",
         "mass": "0.01",
         "volume": "5",
-        "description": "@upgrades/starscanner_2530.image@StarScanner is the most widely used radar in Confed space."
+        "description": "@upgrades/starscanner_2530.image@StarScanner is the most widely used radar in Confed space.",
+        "upgrade": true
     },
     {
         "file": "starscanner2",
@@ -1655,7 +1947,8 @@
         "price": "8000",
         "mass": "0.01",
         "volume": "7",
-        "description": "@upgrades/starscanner_2545.image@StarScanner is the most widely used radar in Confed space."
+        "description": "@upgrades/starscanner_2545.image@StarScanner is the most widely used radar in Confed space.",
+        "upgrade": true
     },
     {
         "file": "starscanner3",
@@ -1663,7 +1956,8 @@
         "price": "16000",
         "mass": "0.01",
         "volume": "9",
-        "description": "@upgrades/starscanner_2600.image@StarScanner is the most widely used radar in Confed space."
+        "description": "@upgrades/starscanner_2600.image@StarScanner is the most widely used radar in Confed space.",
+        "upgrade": true
     },
     {
         "file": "starscanner4",
@@ -1671,7 +1965,8 @@
         "price": "24000",
         "mass": "0.01",
         "volume": "9",
-        "description": "@upgrades/starscanner_2600.image@This is a mid-life upgrade of the StarScanner 2600 that includes threat assessment, which makes it the natural choice for bounty hunters."
+        "description": "@upgrades/starscanner_2600.image@This is a mid-life upgrade of the StarScanner 2600 that includes threat assessment, which makes it the natural choice for bounty hunters.",
+        "upgrade": true
     },
     {
         "file": "hawkeye1",
@@ -1679,7 +1974,8 @@
         "price": "32000",
         "mass": "0.01",
         "volume": "13",
-        "description": "@upgrades/hawkeye_zx16.image@Hawkeye is the preferred radar for Confed military operations."
+        "description": "@upgrades/hawkeye_zx16.image@Hawkeye is the preferred radar for Confed military operations.",
+        "upgrade": true
     },
     {
         "file": "hawkeye2",
@@ -1687,7 +1983,8 @@
         "price": "64000",
         "mass": "0.01",
         "volume": "17",
-        "description": "@upgrades/hawkeye_zx50.image@Hawkeye is the preferred radar for Confed military operations."
+        "description": "@upgrades/hawkeye_zx50.image@Hawkeye is the preferred radar for Confed military operations.",
+        "upgrade": true
     },
     {
         "file": "hawkeye3",
@@ -1695,7 +1992,8 @@
         "price": "128000",
         "mass": "0.01",
         "volume": "21",
-        "description": "@upgrades/hawkeye_zx86.image@Hawkeye is the preferred radar for Confed military operations."
+        "description": "@upgrades/hawkeye_zx86.image@Hawkeye is the preferred radar for Confed military operations.",
+        "upgrade": true
     },
     {
         "file": "hawkeye4",
@@ -1703,7 +2001,8 @@
         "price": "160000",
         "mass": "0.01",
         "volume": "21",
-        "description": "@upgrades/hawkeye_zx86.image@Hawkeye ZX-87 is an upgrade of Hawkeye ZX-86 designed for capital ships."
+        "description": "@upgrades/hawkeye_zx86.image@Hawkeye ZX-87 is an upgrade of Hawkeye ZX-86 designed for capital ships.",
+        "upgrade": true
     },
     {
         "file": "surveyor1",
@@ -1711,7 +2010,8 @@
         "price": "700000",
         "mass": "0.01",
         "volume": "15",
-        "description": "The award-winning H-line is another quality product of Highborn craftsmanship. Designed for tactical superiority, the radar models space at close and distant ranges."
+        "description": "The award-winning H-line is another quality product of Highborn craftsmanship. Designed for tactical superiority, the radar models space at close and distant ranges.",
+        "upgrade": true
     },
     {
         "file": "surveyor2",
@@ -1719,7 +2019,8 @@
         "price": "900000",
         "mass": "0.01",
         "volume": "16",
-        "description": "The award-winning H-line is another quality product of Highborn craftsmanship. Designed for tactical superiority, the radar models space at close and distant ranges. High-lights attacking missiles and ships with high firepower."
+        "description": "The award-winning H-line is another quality product of Highborn craftsmanship. Designed for tactical superiority, the radar models space at close and distant ranges. High-lights attacking missiles and ships with high firepower.",
+        "upgrade": true
     },
     {
         "file": "rlaantracker1",
@@ -1727,7 +2028,8 @@
         "price": "240000",
         "mass": "0.01",
         "volume": "7",
-        "description": "The Tracker is a great all-rounder, popular in both the Rlaan Enforcer and Merchant fleets, because of its unique ability to easily distinguish between ships and celestrial bodies. It is robust towards ECM. The Rlaan eye only perceives depth when it moves, and this trait is found again in this radar."
+        "description": "The Tracker is a great all-rounder, popular in both the Rlaan Enforcer and Merchant fleets, because of its unique ability to easily distinguish between ships and celestrial bodies. It is robust towards ECM. The Rlaan eye only perceives depth when it moves, and this trait is found again in this radar.",
+        "upgrade": true
     },
     {
         "file": "add_cargo_expansion",
@@ -1735,7 +2037,8 @@
         "price": "100000",
         "mass": "10",
         "volume": "20",
-        "description": "@cargo/cargo_expansion.image@Trades upgrade space and support systems for cargo volume"
+        "description": "@cargo/cargo_expansion.image@Trades upgrade space and support systems for cargo volume",
+        "upgrade": true
     },
     {
         "file": "mult_shady_moreupgrade",
@@ -1743,7 +2046,8 @@
         "price": "32000",
         "mass": "10",
         "volume": "50",
-        "description": "@cargo/cargo_hud.image@Trades cargo space for upgrade room."
+        "description": "@cargo/cargo_hud.image@Trades cargo space for upgrade room.",
+        "upgrade": true
     },
     {
         "file": "mult_shady_morethrust",
@@ -1751,7 +2055,8 @@
         "price": "64000",
         "mass": "4",
         "volume": "8",
-        "description": "@weapons/beamtexture2.image@More thruster nodes, less engine shielding."
+        "description": "@weapons/beamtexture2.image@More thruster nodes, less engine shielding.",
+        "upgrade": true
     },
     {
         "file": "mult_shady_moreshields",
@@ -1759,7 +2064,8 @@
         "price": "113000",
         "mass": "0.1",
         "volume": "1",
-        "description": "@weapons/beamtexture.image@Increased shield capacity at the expense of weakened main-hull structural integrity."
+        "description": "@weapons/beamtexture.image@Increased shield capacity at the expense of weakened main-hull structural integrity.",
+        "upgrade": true
     },
     {
         "file": "mult_shady_moregunrecharge",
@@ -1767,7 +2073,8 @@
         "price": "250000",
         "mass": "0.1",
         "volume": "0.25",
-        "description": "@upgrades/circuit1.image@Trades energy capacity for recharge rate."
+        "description": "@upgrades/circuit1.image@Trades energy capacity for recharge rate.",
+        "upgrade": true
     },
     {
         "file": "mult_shady_moreshieldrecharge",
@@ -1775,7 +2082,8 @@
         "price": "500000",
         "mass": "1.1",
         "volume": "5",
-        "description": "@upgrades/mult_shield_regenerator.image@Increases effective ship mass, increases shield recharge."
+        "description": "@upgrades/mult_shield_regenerator.image@Increases effective ship mass, increases shield recharge.",
+        "upgrade": true
     },
     {
         "file": "mult_shady_moreturning",
@@ -1783,7 +2091,8 @@
         "price": "600000",
         "mass": "3.7",
         "volume": "8",
-        "description": "@upgrades/mult_turn_jet_enhancer.image@Violates safety specifications to increase maneuvering performance."
+        "description": "@upgrades/mult_turn_jet_enhancer.image@Violates safety specifications to increase maneuvering performance.",
+        "upgrade": true
     },
     {
         "file": "repair_droid01",
@@ -1791,7 +2100,8 @@
         "price": "30000",
         "mass": "1",
         "volume": "2",
-        "description": "@cargo/repair_droid01.image@Repairs ship upgrades in-flight"
+        "description": "@cargo/repair_droid01.image@Repairs ship upgrades in-flight",
+        "upgrade": true
     },
     {
         "file": "repair_droid02",
@@ -1799,7 +2109,8 @@
         "price": "75000",
         "mass": "5",
         "volume": "4",
-        "description": "@cargo/repair_droid01.image@Repairs ship upgrades in-flight"
+        "description": "@cargo/repair_droid01.image@Repairs ship upgrades in-flight",
+        "upgrade": true
     },
     {
         "file": "repair_droid03",
@@ -1807,7 +2118,8 @@
         "price": "147000",
         "mass": "20",
         "volume": "8",
-        "description": "@cargo/repair_droid01.image@Repairs ship upgrades in-flight"
+        "description": "@cargo/repair_droid01.image@Repairs ship upgrades in-flight",
+        "upgrade": true
     },
     {
         "file": "repair_droid04",
@@ -1815,7 +2127,8 @@
         "price": "290000",
         "mass": "50",
         "volume": "16",
-        "description": "@cargo/repair_droid01.image@Repairs ship upgrades in-flight"
+        "description": "@cargo/repair_droid01.image@Repairs ship upgrades in-flight",
+        "upgrade": true
     },
     {
         "file": "repair_droid05",
@@ -1823,7 +2136,8 @@
         "price": "500000",
         "mass": "100",
         "volume": "32",
-        "description": "@cargo/repair_droid01.image@Repairs ship upgrades in-flight"
+        "description": "@cargo/repair_droid01.image@Repairs ship upgrades in-flight",
+        "upgrade": true
     },
     {
         "file": "ecm_package01",
@@ -1831,7 +2145,8 @@
         "price": "5000",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/ecm1.image@Electronic CounterMeasures\\ ECM refers to a broad spectrum of techniques designed to defeat or spoof enemy sensors and communications."
+        "description": "@upgrades/ecm1.image@Electronic CounterMeasures\\ ECM refers to a broad spectrum of techniques designed to defeat or spoof enemy sensors and communications.",
+        "upgrade": true
     },
     {
         "file": "ecm_package02",
@@ -1839,7 +2154,8 @@
         "price": "20000",
         "mass": "0.05",
         "volume": "2",
-        "description": "@upgrades/ecm2.image@Electronic CounterMeasures\\ ECM refers to a broad spectrum of techniques designed to defeat or spoof enemy sensors and communications."
+        "description": "@upgrades/ecm2.image@Electronic CounterMeasures\\ ECM refers to a broad spectrum of techniques designed to defeat or spoof enemy sensors and communications.",
+        "upgrade": true
     },
     {
         "file": "ecm_package03",
@@ -1847,7 +2163,8 @@
         "price": "50000",
         "mass": "0.1",
         "volume": "3",
-        "description": "@upgrades/ecm3.image@Electronic CounterMeasures\\ ECM refers to a broad spectrum of techniques designed to defeat or spoof enemy sensors and communications."
+        "description": "@upgrades/ecm3.image@Electronic CounterMeasures\\ ECM refers to a broad spectrum of techniques designed to defeat or spoof enemy sensors and communications.",
+        "upgrade": true
     },
     {
         "file": "hud_repair",
@@ -1855,7 +2172,8 @@
         "price": "0",
         "mass": "0.01",
         "volume": "1",
-        "description": "@upgrades/circuit2.image@Given that any craft of decent size has no physical viewport for its pilot, and that no pilot could fly without the nav cues overlaid by the HUD, the ability to do in-flight repair of damaged HUD systems is nearly vital."
+        "description": "@upgrades/circuit2.image@Given that any craft of decent size has no physical viewport for its pilot, and that no pilot could fly without the nav cues overlaid by the HUD, the ability to do in-flight repair of damaged HUD systems is nearly vital.",
+        "upgrade": true
     },
     {
         "file": "cloaking_device",
@@ -1863,7 +2181,8 @@
         "price": "1000000",
         "mass": "8.9",
         "volume": "5",
-        "description": "@cargo/cloaking_device_aeramilspec.image@A dire necessity for those wishing to remain undetected, it is not, however, capable of permanently fooling modern sensor technology."
+        "description": "@cargo/cloaking_device_aeramilspec.image@A dire necessity for those wishing to remain undetected, it is not, however, capable of permanently fooling modern sensor technology.",
+        "upgrade": true
     },
     {
         "file": "passenger_quarters_01",
@@ -1871,7 +2190,8 @@
         "price": "20000",
         "mass": "0.5",
         "volume": "3",
-        "description": "@upgrades/passenger_cryo_chamber.image@All the life-support a frozen passenger needs to survive the journey in a depressurized cargo hold. Provides life-support and space for 1 passenger."
+        "description": "@upgrades/passenger_cryo_chamber.image@All the life-support a frozen passenger needs to survive the journey in a depressurized cargo hold. Provides life-support and space for 1 passenger.",
+        "upgrade": true
     },
     {
         "file": "passenger_quarters_02",
@@ -1879,7 +2199,8 @@
         "price": "50000",
         "mass": "0.8",
         "volume": "21",
-        "description": "@upgrades/passenger_steerage_class.image@Part of the cargo hold is just equipped with an additional life-support for whatever kind of atmosphere is needed for the merry guests standing there or sitting on the floor. Provides life-support and space for up to 4 passengers."
+        "description": "@upgrades/passenger_steerage_class.image@Part of the cargo hold is just equipped with an additional life-support for whatever kind of atmosphere is needed for the merry guests standing there or sitting on the floor. Provides life-support and space for up to 4 passengers.",
+        "upgrade": true
     },
     {
         "file": "passenger_quarters_03",
@@ -1887,7 +2208,8 @@
         "price": "100000",
         "mass": "1",
         "volume": "21",
-        "description": "@upgrades/passenger_economy_class.image@Life-support and even seats for the dear customer. Provides life-support and space for up to 4 passengers."
+        "description": "@upgrades/passenger_economy_class.image@Life-support and even seats for the dear customer. Provides life-support and space for up to 4 passengers.",
+        "upgrade": true
     },
     {
         "file": "passenger_quarters_04",
@@ -1895,6 +2217,7 @@
         "price": "200000",
         "mass": "1.2",
         "volume": "25",
-        "description": "@upgrades/passenger_comfort_class.image@Life-support, seat and even bunk-beds provide a level of comfort the captain would like to have. Provides life-support and space for up to 2 passengers."
+        "description": "@upgrades/passenger_comfort_class.image@Life-support, seat and even bunk-beds provide a level of comfort the captain would like to have. Provides life-support and space for up to 2 passengers.",
+        "upgrade": true
     }
 ]

--- a/master_component_list.json
+++ b/master_component_list.json
@@ -223,7 +223,6 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@The logical conclusion of decades of upscaling work with spatial disruption technology, this weapon finds its home only among the weapons mounted on the capital vessels of well funded space navies.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -234,7 +233,6 @@
         "volume": "1",
         "description": "@upgrades/beam2.image@Like fireworks - only full of razorblades.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -245,7 +243,6 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@There, there Snowden.... there, there.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -256,7 +253,6 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@A variant of the Disruptor Beam, this weapon uses the same functional principals, but is engineered for use at long range. Projecting something that is, in many respects, an extremely long sliver of a shield poses a number of technical difficulties. Long range disruptor beams increase the effective range of the weapon, but at the cost of dramatic reductions to efficiency, damage output, and beam stability alongside a significantly increased physical size. However, for certain applications, such as point-defense emplacements, these trade-offs have been considered more than worthwhile.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -267,7 +263,6 @@
         "volume": "1",
         "description": "@upgrades/medium.image@While slinging particles of negligible mass, and in chaste quantities, this weapon does manage to propel them at significant fractions of lightspeed, rendering the particles quite dangerous to encounter.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -278,7 +273,6 @@
         "volume": "1",
         "description": "@upgrades/heavy.image@The standard armament of most heavy Aeran vessels, this is a scaled up version of the same PESC type warhead delivery system used in Aeran combat craft.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -289,7 +283,6 @@
         "volume": "1",
         "description": "@upgrades/medium.image@A long ranged laser weapon used primarily in Aeran point defence emplacements.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -300,7 +293,6 @@
         "volume": "1",
         "description": "@upgrades/medium.image@Rapid-fire microwave laser: When an enemy vessel has had enough it will go 'ding'. Or, possibly, explode.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -311,7 +303,6 @@
         "volume": "1",
         "description": "@upgrades/heavy.image@Microwave laser: Caution -- do not stand in front of laser when attempting to defrost chickens.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -322,7 +313,6 @@
         "volume": "1",
         "description": "@upgrades/heavy.image@Rapid-fire infrared laser: Even on the coldest sea, it can still be Hot, Hot, Hot!",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -333,7 +323,6 @@
         "volume": "1",
         "description": "@upgrades/heavy.image@Infrared laser: When using for grilling, please refrain from putting hands, feet, or population centers in front of the lasing surface.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -344,7 +333,6 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@The Jackhammer is an open-cycle laser, venting its coolant after every firing sequence. While this does wonders for the size and complexity of the cooling system, it does raise ammunition capacity issues not frequently associated with modern lasers.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -355,7 +343,6 @@
         "volume": "1",
         "description": "@cargo/halogen_gasses.image@Coolant for the open-cycle Jackhammer laser.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -366,7 +353,6 @@
         "volume": "1",
         "description": "@upgrades/turret_heavy.image@Rapid-fire UV Laser. UV and other higher frequency lasers raise increasing concerns about cooling. Fortunately, UV and higher frequency lasers are effective enough to warrant being built into capital sized mounts that can handle their cooling requirements.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -377,7 +363,6 @@
         "volume": "1",
         "description": "@upgrades/turret_heavy.image@UV Laser. Unlike most exposures to UV light, taking in these rays decreases the risk of dying from skin cancer.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -388,7 +373,6 @@
         "volume": "1",
         "description": "@upgrades/turret_heavy.image@Rapid-fire Xaser. Used properly, one can use a Xaser to figure out what the inside of an enemy vessel looks like. The crew, however, tends to cease to have insides at about the same time.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -399,7 +383,6 @@
         "volume": "1",
         "description": "@upgrades/turret_heavy.image@Xaser. The X-ray spectrum and lasers are notoriously unfriendly to being combined. That xasers exist at all just goes to show that some relationships can be made to work if there's enough money in it for everyone else involved.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -410,7 +393,6 @@
         "volume": "1",
         "description": "@upgrades/medium.image@It has long been known that lightweight, charged particles, while easy to accelerate, suffer greatly from electro-static bloom effects. However, it has also long been known that there's not much in the universe cheaper to obtain than lightweight, charged particles. Still, it's not your great-to-the-Nth-granddaddy's cathode ray tube. (It's a lot bigger than that).",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -421,7 +403,6 @@
         "volume": "1",
         "description": "@upgrades/medium.image@Adding a bit more heft to the input stream than what is found in weapons termed particle beams, this weapon nonetheless operates on the same general principles. The electric charge of ionized plasma makes it particularly easy to compress and fire using simple magnetics. Deceptively simple in design, these weapons' cost comes from the inherent difficulty in making a stream of ionized plasma remain coherent _after_ firing. In the last ten years, advances in this field have led to noted increases in the accessibility of ion beam weapons, and to a market glut of cheap knockoff brands.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -432,7 +413,6 @@
         "volume": "1",
         "description": "@upgrades/heavy.image@A variant of the somewhat more common Ion Beam, these weapons utilizes heavier ions, such as xenon. Heavier ions are more difficult to accelerate to the desired exit velocities, but do not suffer nearly as much from electro-static bloom effects as their lighter counterparts.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -443,7 +423,6 @@
         "volume": "1",
         "description": "@upgrades/beam2.image@One of the smallest of the ion weapon family, the Ion Burster, despite a seemingly projectile output, is more closely related to ion beam weapons than to anything else. Indeed, the lower speed and packetized nature of the weapon's output are not so much desirable attributes as concessions: in order to make the weapon small enough to meet design specifications, the beam can only be pulsed, and infrequently at that. To compensate for this disability, the Ion Burster relies on specially prepared vaporization plates, rather than the homogeneous gas-streams ususally feeding Ion weapons.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -454,7 +433,6 @@
         "volume": "1",
         "description": "@cargo/halogen_gasses.image@Prepackaged vaporization plates for the Ion Burster gun.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -465,7 +443,6 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@The canonical example of shield-based weaponry, the disruptor beam is highly effective at disrupting the twisted maze of forces created by a shield generator, but entirely unequipped to trickle damage past a shield until the shield in question has already nearly faltered. Disruptors, just like the shields they share most of their technological lineage with, interact violently with matter, making them poorly suited to use outside of vacuum. Fortunately for those on the receiving end of a disruptor blast, even a shield de-patterned to the point of collapse will mitigate a disruptor's effects on materials beyond the shield. Unfortunately for those on the receiving end of a disruptor, mitigate is not the same as eliminate. Those unfortunate enough to receive disruptor fire with no shield generator at all are usually at least fortunate enough that the shear forces kill them before they can notice. This design is exceptionally popular among adherents to the trekkie religion, but its reliability and effectiveness make it nothing to scoff at.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -476,7 +453,6 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@This Highborn Milspec weapon was designed alongside the Lancelot superiority fighter. If nearly equivalent in fundamental design principles, its implementation and engineering is superior in nearly every respect to the Disruptor Beams it shares a common origin with. In keeping with the naming of the ship it was co-designed with, the Shield Breaker is well suited to render any shield within reach quite humbled in but a small number of lancing blows.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -487,7 +463,6 @@
         "volume": "1",
         "description": "@upgrades/heavy.image@A variant of the Disruptor Beam, this weapon uses the same functional principals, but is engineered for use at long range. Projecting something that is, in many respects, an extremely long sliver of a shield poses a number of technical difficulties. Long range disruptor beams increase the effective range of the weapon, but at the cost of dramatic reductions to efficiency, damage output, and beam stability alongside a significantly increased physical size. However, for certain applications, such as point-defense emplacements, these trade-offs have been considered more than worthwhile.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -498,7 +473,6 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@The Rlaan have studied disruptor based weaponry for far longer than any other extant species, and this is the most common fruit of that research.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -509,7 +483,6 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@A version of the Rlaan Ktek beam repurposed for point defense installations.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -520,7 +493,6 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@Originally developed to break apart debris fields, this medium sized pulsed disruptor weapon is very deadly at close range. However, as the pulses, once disconnected from their generator, move slowly and rapidly decay, this weapon is of questionable value at any significant distance.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -531,7 +503,6 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@What Rlaan do to the erstwhile laws of physics in their own homes is their own business. When they do it on the business end of this space-disrupting weapon, its everyone else's business to not be in the way. This miniature version of the Janissary class main weapon is used in lieu of torpedos by Rlaan assault craft.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -542,7 +513,6 @@
         "volume": "1",
         "description": "@upgrades/maul.image@Unlike the larger version of the same device that the Janissary class is built around, the 'mini' version of the grav-thumper renders portions of the device used to generate the distortion damaged and inoperable. Fortunately, the relevant portions are both modular and easily ejected, leading to an ammunition-like solution to the problem.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -553,7 +523,6 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@A pulsed form of the shield-based disruptor beam technology, designs such as this have faded in popularity since the introduction of reliable shield decoupling mechanisms for the beam forms of disruptors. However, the significant time and investment already sunk into such designs, and the continued utility of the extremely high-end pulsed disruptor devices keeps the market stocked with current revisions of this aging weaponry.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -564,7 +533,6 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@The lightest and smallest of the disruptors manufactured by groups in Unadorned space, it can only provide body blows, but can keep on swinging with remarkable stamina.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -575,7 +543,6 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@A standard weapon on light Unadorned craft, the Dissonance is larger, weaker, and slower than the Rlaan Ktek gun, but has a significantly longer effective range.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -586,7 +553,6 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@Sacrificing efficiency and stopping power, this long ranged variant of the ubiquitous disruptor gun makes an effective fly-swatter. Primarily found in turret mounts on ships large enough to afford the energy demands, the low damage output tends to relegate this weapon to a deterrent role rather than the spearpoint of more aggressive actions.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -597,7 +563,6 @@
         "volume": "1",
         "description": "@upgrades/accelerator_gun.image@Long before the dawn of modern man, it was known to various hominids that hurling a blunt object was a reasonable way to deliver damage from a distance. Fittingly enough, the worlds of the Purist faction are among the chief manufacturers of mass drivers.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -608,7 +573,6 @@
         "volume": "1",
         "description": "@upgrades/accelerator_gun.image@Long before the dawn of modern man, it was known to various hominids that hurling a blunt object was a reasonable way to deliver damage from a distance. Fittingly enough, the worlds of the Purist faction are among the chief manufacturers of mass drivers.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -619,7 +583,6 @@
         "volume": "1",
         "description": "@upgrades/accelerator_gun.image@Very small, very dense, somewhat cheap, magnetically reactive.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -630,7 +593,6 @@
         "volume": "1",
         "description": "@upgrades/accelerator_gun.image@Small, dense, cheap, magnetically reactive.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -641,7 +603,6 @@
         "volume": "0.1",
         "description": "@upgrades/accelerator_gun.image@A scaled down version of the electromagnetic accelerator used in the Hephaestus point defense emplacements, this Andolian death-dealer is special less in its ability to fling its projectiles rapidly and at high velocity than its compatibility with a very particular projectile of Andolian manufacture.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -652,7 +613,6 @@
         "volume": "0.1",
         "description": "@upgrades/swarm.image@The ammunition for the Hephaestus mini-driver is by far one of the smallest and most advanced shield-piercing rounds developed to date.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -663,7 +623,6 @@
         "volume": "1",
         "description": "@upgrades/light.image@Though not a laser by any stretch of the imagination, due to its resemblance to the so called 'lasers' of classic games and movies of the previous millenium, the misnomer has stuck stronger than space rated epoxy. Cheap and utterly dependable, this and other similar low yield exhaust-compression weapons are ubiquitous in armed civilian populations.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -674,7 +633,6 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@The trick, as many an unfortunate pirate has learned by experience, is to keep sufficient distance that the disabled enemy vessel is not accidently welded to your own ship. When used on security drones, the welding failure-mode is seen as more of a bonus.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -685,7 +643,6 @@
         "volume": "1",
         "description": "@upgrades/beam2.image@Like the Crippler, the leech gun relies on sophisticated projectiles housing single-shot laser warheads and minimal targeting systems to do the dirty work of rendering a target vessel disabled. Unlike the Crippler, the leech gun has a reputation for being sufficiently underpowered that it's dangerous to not pack more lethal weaponry as well.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -696,7 +653,6 @@
         "volume": "1",
         "description": "@upgrades/beam2.image@Originally designed for IntelSec and Homeland Security forces, the Crippler has reached increasingly large customer bases in the many decades since its introduction. Most experts believe this to be due to the fact that competitors looking to enter the less-than-lethal weapons market have tended to underestimate how difficult it is to hit appropriate subsystems to render a craft disabled but intact.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -707,7 +663,6 @@
         "volume": "1",
         "description": "@upgrades/light.image@It's a (plasma) flamethrower! ... in space! If you can actually get close enough to hit anything, the ionization can disable all sort and manner of targetted electrical systems, but the plasma plume's range tends to limit its applications to relatively stationary objects. Cheap as vaccuum, flashy as a nova, and unlikely to cause any real harm, this is a favored weapon of rent-a-cops and parking enforcement officials everywhere. ",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -718,7 +673,6 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@The oldest active armament of what would come to be a long series of Aeran PESC (Photon Emission on Shield Collapse) weapons, the gun itself is a non-descript warhead accelerator designed around the MK I PESC ammunition.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -729,7 +683,6 @@
         "volume": "1",
         "description": "@upgrades/beam2.image@A significant improvement with respect to the MK I in both accelerator and warhead, the MK II is a briusing weapon with solid shield penetration still heavily in service across the entire Aeran fleet.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -740,7 +693,6 @@
         "volume": "1",
         "description": "@upgrades/medium.image@A refinement, rather than an improvement over the MK II, the MK III is a smaller weapon based around a much smaller warhead and a faster rate of fire, extending the PESC weaponry to lighter Aeran craft and emplacements.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -751,7 +703,6 @@
         "volume": "1",
         "description": "@upgrades/razor_gun.image@Sadly enough for their former marketing exectutives, 'Ring around the targets, pocket-size the fuzies, deuterium-deuterium, they all go boom!' did not in fact make for a good advertising campaign.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -762,7 +713,6 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@The grimmest part of this Reaper is probably the 37 page manual on the appropriate handling of the anti-matter filled rounds. The gun itself, after all, is a rather sporty number.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -773,7 +723,6 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@Aeran PESC (Photon Emission on Shield Collapse) Warhead. Essentially consisting of a faulty shield generator in miniature, on contact with any shield or object, the warhead's shield will collapse through the warhead itself, emitting a large number of high-energy photons in the process, thus lending notable shield-penetrating damage. While the root principle has been known to all of the major space-faring groups for some time, only the Aera have pursured significant weaponization.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -784,7 +733,6 @@
         "volume": "1",
         "description": "@upgrades/beam2.image@Aeran PESC (Photon Emission on Shield Collapse) Warhead. Essentially consisting of a faulty shield generator in miniature, on contact with any shield or object, the warhead's shield will collapse through the warhead itself, emitting a large number of high-energy photons in the process, thus lending notable shield-penetrating damage. While the root principle has been known to all of the major space-faring groups for some time, only the Aera have pursured significant weaponization.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -795,7 +743,6 @@
         "volume": "1",
         "description": "@upgrades/medium.image@Aeran PESC (Photon Emission on Shield Collapse) Warhead. Essentially consisting of a faulty shield generator in miniature, on contact with any shield or object, the warhead's shield will collapse through the warhead itself, emitting a large number of high-energy photons in the process, thus lending notable shield-penetrating damage. While the root principle has been known to all of the major space-faring groups for some time, only the Aera have pursured significant weaponization.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -806,7 +753,6 @@
         "volume": "1",
         "description": "@upgrades/razor_gun.image@Each Razor round is a miniature fusion device, and a real pain to get through customs.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -817,7 +763,6 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@Keeping an anti-matter containment unit intact when being hurled out of a gun at several kilometers per second is no trivial matter, as the pricetag will verify.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -828,7 +773,6 @@
         "volume": "1",
         "description": "@missile-hud.image@Echewing strong AI, the Rlaan rely on an engineered species derived from something akin to a hunting dog to pilot their drones. Most other species find the idea of giving disembodied pet brains firing control over energy weapons to be mildly disconcerting. The Hellspawn model is one of the smaller Rlaan drones, consisting of little more than two turrets, sensors, and a drive system. Survivability is not a priority, as evidenced by the sizeable self-destruct package.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -839,7 +783,6 @@
         "volume": "1",
         "description": "\"@upgrades/swarm.image@While individually fairly worthless, the PC-031 \"\"Stormfire\"\" rounds were designed as a low-yield, low-overhead projectiles that could be rapidly emmitted in high numbers by fighters with multiple weapon mountpoints, or as point defense on capital ships. Surplus Stormfires have seen additional use among merchants as cheap, reliable alternatives to energy weapons. \"",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -850,7 +793,6 @@
         "volume": "1",
         "description": "@upgrades/medium.image@As may be expected of a device created to sling anti-matter, any error during the firing process will not merely slag the gun, but may evapourate it and a large portion of the vessel on which it is mounted; thus, every aspect of the process is perfectly controlled and subject to significant redundancy. Needless to say, such engineering does not come cheap.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -861,7 +803,6 @@
         "volume": "1",
         "description": "@cargo/tractor_beam.image@Gravitic technology can be used in a wide variety of ways: arguably, the most popular is keeping your soup in its bowl. A tractor beam, on the other hand, is good at putting somebody else's soup in your bowl. ",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -872,7 +813,6 @@
         "volume": "1",
         "description": "@cargo/repulsor_beam.image@Repulsor beams, relatively new items on the market, have seen considerable use in large-scale construction projects ever since it was discovered how to keep them from mangling the point of contact; some creative combatants have found different uses for them.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -883,7 +823,6 @@
         "volume": "1",
         "description": "@cargo/tractor_heavy.image@Animal magnetism is overrated.  This is just over-engineered. Capable of producing a g-forces that would turn people, elephants, and any appropriately hued fruits into raspberry colored toast topping, heavy tractor beams are rarely seen outside of deepspace construction yards and piracy organizations.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -894,7 +833,6 @@
         "volume": "1",
         "description": "@cargo/tractor_capability.image@Traditionally, most weapon mounts aren't constructed to handle the strains associated with tractor beam usage. Fortunately, this is usually a cost-cutting measure, and installing the necessary reinforcements doesn't tend to interfere with the weapon mount, although it may void certain warranties. ",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -905,7 +843,6 @@
         "volume": "1",
         "description": "@upgrades/circuit1.image@While all mounted weapons have inherent auto-tracking capabilities, these defaults are limited in civilian mounts. A full-powered military auto-tracker like this greatly enhances weapon accuracy.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -916,7 +853,6 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@The Rlaan are well known for their disdain of missiles, especially those fired at them.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -927,7 +863,6 @@
         "volume": "1",
         "description": "@upgrades/turret_medium.image@While Rlaan ships tend to mount flash-shields capable of shrugging off most small arms fire, they still prefer the option of 'convincing' fighters to stop firing.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -938,7 +873,6 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@Using low yield pulse lasers, the aera have made simple and effective anti-missile turrets.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -949,7 +883,6 @@
         "volume": "1",
         "description": "@upgrades/turret_heavy.image@Specially designed for the energy and heat dissipation requirements of beam weapons, this turret has everything you need to mount a pair of them.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -960,7 +893,6 @@
         "volume": "1",
         "description": "@upgrades/beam3.image@One is heavily advised to not play 'catch the missile' unless one mounts several of these.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -971,7 +903,6 @@
         "volume": "1",
         "description": "@upgrades/turret_heavy.image@For when evasive maneuvers are too subtle a hint your tailgaters.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -982,7 +913,6 @@
         "volume": "1",
         "description": "@upgrades/turret_light.image@Given the armament commonly placed in such turrets, the small turret has become affectionately known as 'the machine that goes ping'.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -993,7 +923,6 @@
         "volume": "1",
         "description": "@upgrades/turret_medium.image@It turns, it shoots, it slices. No, it does not dice, but it does come with a free fuzzy pair.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1004,7 +933,6 @@
         "volume": "1",
         "description": "@upgrades/razor_gun.image@When hunting for bear, hover softly, and carry a big stick",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1015,7 +943,6 @@
         "volume": "1",
         "description": "@upgrades/beam2.image@If your vessel can mount this, this can mount whatever you want.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1026,7 +953,6 @@
         "volume": "1",
         "description": "@upgrades/beam1.image@One of the most impressive applications of disruptor technology, this military rated point defense turret is the best of its kind.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1037,7 +963,6 @@
         "volume": "1",
         "description": "@../units/franklin/franklin-hud.image@These turrets were custom designed for the Franklin class diplomatic transport. Any hotshot who splurges on the Franklin should undoubtedly get these fine turrets to complement the exterior decor.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1048,7 +973,6 @@
         "volume": "0.1",
         "description": "@missile-hud.image@Behold KE=1/2MV^2: large values of M and high values of V yield large numbers of obliterated fragments of intended targets. (Capital sized launch platform sold separately, shield batteries included.)",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1059,7 +983,6 @@
         "volume": "0.1",
         "description": "@upgrades/capiff.image@Drawing upon the greater sensor capability and volumetric resources of a capital vessel, these larger IFF missiles can deliver a larger payload over a much longer intercept sphere than their fighter-launched cousins.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1070,7 +993,6 @@
         "volume": "0.1",
         "description": "@upgrades/capiff.image@Drawing upon the greater sensor capability and volumetric resources of a capital vessel, these larger IFF missiles can deliver a larger payload over a much longer intercept sphere than their fighter-launched cousins.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1081,7 +1003,6 @@
         "volume": "0.1",
         "description": "@upgrades/missile.image@Capital ships benefit both from being large enough to launch effective cluster munitions and robust enough to not worry about doorstep detonations.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1092,7 +1013,6 @@
         "volume": "0.1",
         "description": "@upgrades/capshipmissile.image@As large as some insystem fighters and sporting the latest in stealth and ECCM technology, these SPEC capable missiles, frequently seen tipped with warheads in the 10 megaton or higher range, can make dropping one's shields to retreat a truly nerve-wracking decision.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1103,7 +1023,6 @@
         "volume": "0.1",
         "description": "@upgrades/emp2.image@The spinal mounted armament of the Leonidas class dreadnaughts is something to behold. If the principle behind the massive accelerators is not novel, their scale remains awe-inspiring.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1114,7 +1033,6 @@
         "volume": "0.1",
         "description": "@upgrades/dumbfire.image@Removing maneuvering jets capable of counteracting a missile's momentum leaves a lot more room for a warhead. Of course, it also makes for a missile that only flies in a straight line.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1125,7 +1043,6 @@
         "volume": "0.1",
         "description": "@upgrades/heatseeker.image@A missile which locks onto a heat source -- a ship's engines, for example -- rather than a radar or IFF signal. The Heatseeker is not as vulnerable to ECM as torpedoes, IFF or other guided missiles are. Damage is respectable for their small size. They are also relatively inexpensive and widely available. Most effective against light and medium ships. They are best used in salvos rather than individually. One missile often will weaken the target's defenses enough to let the others get through and do damage to the ship itself. CAUTION: If you are attacking targets near a friendly capship, heat seekers launched at targets within a few hundred meters from the capship may well lock onto the capship instead. That tends to get you talked about by the capship. ",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1136,7 +1053,6 @@
         "volume": "0.1",
         "description": "@upgrades/imrec.image@Like an obsessive-compulsive stalker, once it knows what you look like, it's not going to stop showing up at your doorstep.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1147,7 +1063,6 @@
         "volume": "0.1",
         "description": "@upgrades/fof.image@There are those who, steadfast in their desire to reduce signals cluttering battlefield communications, have advocated abandoning traditional IFF mechanisms. Fortunately for missile and sensor manufacturers everywhere, such proponents have a remarkable tendency to find their ships hit by IFF missiles.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1158,7 +1073,6 @@
         "volume": "0.1",
         "description": "@upgrades/emp1.image@Featuring bulk and drive style rapidly approaching that of a small vessel, these beasts pack a heavy punch, but tend to have acceleration curves suited to catching only the less than fleet of foot.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1169,7 +1083,6 @@
         "volume": "0.1",
         "description": "@upgrades/missile.image@The Aeran equivalent of the Confederation torpedo is just as sluggish, but packs a more vicious punch.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1180,7 +1093,6 @@
         "volume": "0.1",
         "description": "@upgrades/emp3.image@Employed in increasingly large numbers by regional guard units, EMP torpedos seek to sufficiently damage the electronics of a vessel so as to render it out of user control. Such devices, in the absence of an atmosphere to assist with EMP effects, must be quite large, and have thus been adapted to a torpedo chassis.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1191,7 +1103,6 @@
         "volume": "0.1",
         "description": "@upgrades/swarm.image@An older Aeran PESC mini-warhead adapted for rocket pod distribution.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1202,7 +1113,6 @@
         "volume": "0.1",
         "description": "@upgrades/cluster.image@While fighter-mounted cluster missiles are unlikely to actually destroy any vessels, they are extremely useful for getting the attention of several craft in one go.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1213,7 +1123,6 @@
         "volume": "0.1",
         "description": "@upgrades/swarm.image@If you love the smell of Katyushas in the morning, then you probably already have one of these.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1224,7 +1133,6 @@
         "volume": "0.1",
         "description": "@upgrades/swarm.image@A more recently developed Aeran PESC mini-warhead, photon swarm rocket pods are extremely common on Aeran light craft.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1235,7 +1143,6 @@
         "volume": "0.1",
         "description": "@upgrades/swarm.image@Like their namesake, one sting won't hurt too much, but nobody fires just one of these.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1246,7 +1153,6 @@
         "volume": "0.1",
         "description": "@upgrades/swarm.image@Sometimes it rains, sometimes it hails, but when you're armed with Hail emplacents, it rains death from above.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1257,7 +1163,6 @@
         "volume": "0.1",
         "description": "@upgrades/missile.image@An otherwise unremarkable missile with an odd aspect ratio.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1268,7 +1173,6 @@
         "volume": "0.1",
         "description": "@upgrades/porcupine_mine.image@Dropped by Aeran mine-layers and, in smaller numbers, other small craft, these mines each mount a single gun with a limited number of rounds. Once ammunition or energy is depleted, the mines self-destruct. These mines are used in both defensive emplacements and as a harassing distraction against pursuing craft.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {
@@ -1279,7 +1183,6 @@
         "volume": "1",
         "description": "@upgrades/leech.image@Complicated rounds with sensors and one-shot lasers designed to disable, not destroy, enemy craft.",
         "upgrade": true,
-        "weapoon": true,
         "weapon": true
     },
     {

--- a/master_part_list.json
+++ b/master_part_list.json
@@ -5,7 +5,8 @@
         "price": "0",
         "mass": "4",
         "volume": "100",
-        "description": "@cargo/first_class_passenger.image@If you are taking first class passengers around, they had better have all the amenities one expects."
+        "description": "@cargo/first_class_passenger.image@If you are taking first class passengers around, they had better have all the amenities one expects.",
+        "passenger": true
     },
     {
         "file": "Business_Class_Passenger",
@@ -13,7 +14,8 @@
         "price": "0",
         "mass": "3",
         "volume": "50",
-        "description": "@cargo/business_class_passenger.image@With a laptop and a wide rear, the business class passenger enjoys some of the room of the first class passenger."
+        "description": "@cargo/business_class_passenger.image@With a laptop and a wide rear, the business class passenger enjoys some of the room of the first class passenger.",
+        "passenger": true
     },
     {
         "file": "Frozen_Colonist",
@@ -21,7 +23,8 @@
         "price": "0",
         "mass": "1",
         "volume": "3",
-        "description": "@cargo/frozen_colonist.image@Polite, space-efficient, doesn't try to back-seat pilot, doesn't care how long it takes to get there. Unfortunately, being technically, if only temporarily, deceased - not much for conversation."
+        "description": "@cargo/frozen_colonist.image@Polite, space-efficient, doesn't try to back-seat pilot, doesn't care how long it takes to get there. Unfortunately, being technically, if only temporarily, deceased - not much for conversation.",
+        "passenger": true
     },
     {
         "file": "Hitchhiker",
@@ -29,7 +32,8 @@
         "price": "0",
         "mass": "0.4",
         "volume": "6",
-        "description": "@cargo/steerage_class@Always brings a towel of his/her own."
+        "description": "@cargo/steerage_class@Always brings a towel of his/her own.",
+        "passenger": true
     },
     {
         "file": "Ration_Mealpacks",
@@ -1565,7 +1569,9 @@
         "price": "760",
         "mass": "0.15",
         "volume": "2",
-        "description": "@cargo/pilot.image@Much as you may hate the pilot of the ship that attempted to destroy yours, destroying that pilot's ship does not grant one, under interstellar law, the right to sell said pilot into slavery. That being said, many have been known to justify such actions by claiming it to be an entirely proper form of remuneration. [Note to editors: Do not change name as the code relies on Pilot]"
+        "description": "@cargo/pilot.image@Much as you may hate the pilot of the ship that attempted to destroy yours, destroying that pilot's ship does not grant one, under interstellar law, the right to sell said pilot into slavery. That being said, many have been known to justify such actions by claiming it to be an entirely proper form of remuneration. [Note to editors: Do not change name as the code relies on Pilot]",
+        "passenger": true,
+        "slave": true
     },
     {
         "file": "Slaves",
@@ -1573,7 +1579,9 @@
         "price": "750",
         "mass": "0.1",
         "volume": "2",
-        "description": "@cargo/slaves.image@Illegal due to fears of interspecies domination, among a plethora of other reasons, economic inefficiencies looming largest of all."
+        "description": "@cargo/slaves.image@Illegal due to fears of interspecies domination, among a plethora of other reasons, economic inefficiencies looming largest of all.",
+        "passenger": true,
+        "slave": true
     },
     {
         "file": "Clones",


### PR DESCRIPTION
Currently, the game engine assesses cargo based on hard coded strings during runtime. 
e.g. Category starts with upgrades, it's an upgrade. 
I've moved this code to the modifying script. Now, cargo of a certain category has `"<category>": true`.

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Neither really. This is an asset change. I suggest testing in two ways:
1. Check the game works with the change. It's a json, so the engine shouldn't care about "extra" data.
2. Review the changed files.

I've done number 2 already.

Issues:
- None
