### PR TITLE
Windows-CI.yml, Windows-Release.yml: Remove Windows 2019

### DIFF
--- a/.github/workflows/Windows-CI.yml
+++ b/.github/workflows/Windows-CI.yml
@@ -12,8 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os:              windows-2019
-            is-release:      0
           - os:              windows-2022
             is-release:      0
           - os:              windows-2025

--- a/.github/workflows/Windows-Release.yml
+++ b/.github/workflows/Windows-Release.yml
@@ -21,8 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os:              windows-2019
-            is-release:      1
           - os:              windows-2022
             is-release:      1
           - os:              windows-2025


### PR DESCRIPTION
Code Changes:
- [x] This is a CI / build system change only (well, more or less)

Issues:
- N/A

Purpose:
- What is this pull request trying to do? Remove Windows 2019 from the set of operating systems we build on, since GitHub Actions will no longer support it in a few days
- What release is this for? All of them, moving forward
- Is there a project or milestone we should apply this to? 0.10.x?
