### PR TITLE
Support for engine PR 1233

### DIFF
--- a/config.json
+++ b/config.json
@@ -128,7 +128,9 @@
         "ConsoleKeys::BringConsole": {"key": "function-1", "modifier": "ctrl"},
         "SetVelocityRefKey": {"key": "keypad-7", "modifier": "none"},
         "SetVelocityNullKey": {"key": "keypad-1", "modifier": "none"},
-        "Cockpit::Quit": {"key": "esc", "modifier": "none"}
+        "Cockpit::Quit": {"key": "esc", "modifier": "none"},
+        "FreeSlaves": {"key": "f", "modifier": "ctrl"},
+        "Enslave": {"key": "e", "modifier": "ctrl"}
     },
 
     "mouse": {

--- a/master_component_list.json
+++ b/master_component_list.json
@@ -2044,8 +2044,8 @@
         "file": "mult_shady_moreupgrade",
         "categoryname": "upgrades/Shady_Mechanic",
         "price": "32000",
-        "mass": "10",
-        "volume": "50",
+        "mass": "1",
+        "volume": "0.1",
         "description": "@cargo/cargo_hud.image@Trades cargo space for upgrade room.",
         "upgrade": true
     },

--- a/units/units.json
+++ b/units/units.json
@@ -11489,7 +11489,8 @@
         "Name": "More Upgrade Volume",
         "Object_Type": "Upgrade_Improvement",
         "Textual_Description": "\"@cargo/cargo_hud.png@Trades cargo space for upgrade room\"\n",
-        "Hold_Volume": "-50"
+        "Hold_Volume": "-20",
+        "Upgrade_Storage_Volume": "12"
     },
     {
         "Key": "hud_repair__upgrades",

--- a/vegastrike.config
+++ b/vegastrike.config
@@ -284,6 +284,8 @@ Farther down, you will see "#GeomLow". Currently, it's line 213. You'll find mor
 
 
     <bind key="esc" modifier="none" command="Cockpit::Quit"/>
+    <bind key="f" modifier="ctrl" command="FreeSlaves"/>
+    <bind key="e" modifier="ctrl" command="Enslave"/>
 
 <!-- #no_mouse -->
     <bind mouse="0" player="1" button="0" modifier="none" command="FireKey" />


### PR DESCRIPTION
- Fix mult_shady_moreupgrade__upgrades. Note reduction in mass and volume as this is really a service. However, did not want to provide 0 cargo, as that may break the game.
- Add enslave/free key bindings

This PR provides the necessary assets changes to support https://github.com/vegastrike/Vega-Strike-Engine-Source/pull/1233.

Code Changes:
- [x] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation

Issues:
- None identified

