### PR TITLE
Remove missing keys

### DIFF
--- a/python/settings_app/templates/schema.json
+++ b/python/settings_app/templates/schema.json
@@ -44,7 +44,7 @@
             "graphics/star_blend": true,
             "graphics/background": true,
             "graphics/cockpit": true,
-            "graphics/planet_detail_level": 96,
+            "graphics/planet_detail_level": 96
         },
         "Very High": {
             "graphics/fog": true,
@@ -61,7 +61,7 @@
             "graphics/star_blend": true,
             "graphics/background": true,
             "graphics/cockpit": true,
-            "graphics/planet_detail_level": 64,
+            "graphics/planet_detail_level": 64
         },
         "High": {
             "graphics/fog": true,
@@ -79,7 +79,7 @@
             "graphics/star_blend": true,
             "graphics/background": true,
             "graphics/cockpit": true,
-            "graphics/planet_detail_level": 48,
+            "graphics/planet_detail_level": 48
         },
         "Medium": {
             "graphics/fog": false,
@@ -97,7 +97,7 @@
             "graphics/star_blend": true,
             "graphics/background": true,
             "graphics/cockpit": true,
-            "graphics/planet_detail_level": 48,
+            "graphics/planet_detail_level": 48
         },
         "Low": {
             "graphics/fog": false,
@@ -116,7 +116,7 @@
             "graphics/star_blend": false,
             "graphics/background": false,
             "graphics/cockpit": false,
-            "graphics/planet_detail_level": 48,
+            "graphics/planet_detail_level": 48
         },
         "Retro": {
             "graphics/fog": false,
@@ -135,7 +135,7 @@
             "graphics/star_blend": false,
             "graphics/background": false,
             "graphics/cockpit": false,
-            "graphics/planet_detail_level": 24,
+            "graphics/planet_detail_level": 24
         }
     },
     "shaders": {

--- a/python/settings_app/templates/schema.json
+++ b/python/settings_app/templates/schema.json
@@ -42,11 +42,9 @@
             "graphics/znear": 8,
             "graphics/zfar": 65536,
             "graphics/star_blend": true,
-            "graphics/point_sparkles": false,
             "graphics/background": true,
             "graphics/cockpit": true,
             "graphics/planet_detail_level": 96,
-            "graphics/jump_detail": 16
         },
         "Very High": {
             "graphics/fog": true,
@@ -61,11 +59,9 @@
             "graphics/znear": 8,
             "graphics/zfar": 65536,
             "graphics/star_blend": true,
-            "graphics/point_sparkles": false,
             "graphics/background": true,
             "graphics/cockpit": true,
             "graphics/planet_detail_level": 64,
-            "graphics/jump_detail": 16
         },
         "High": {
             "graphics/fog": true,
@@ -81,11 +77,9 @@
             "graphics/znear": 16,
             "graphics/zfar": 32768,
             "graphics/star_blend": true,
-            "graphics/point_sparkles": false,
             "graphics/background": true,
             "graphics/cockpit": true,
             "graphics/planet_detail_level": 48,
-            "graphics/jump_detail": 8
         },
         "Medium": {
             "graphics/fog": false,
@@ -101,11 +95,9 @@
             "graphics/znear": 16,
             "graphics/zfar": 32768,
             "graphics/star_blend": true,
-            "graphics/point_sparkles": false,
             "graphics/background": true,
             "graphics/cockpit": true,
             "graphics/planet_detail_level": 48,
-            "graphics/jump_detail": 8
         },
         "Low": {
             "graphics/fog": false,
@@ -122,11 +114,9 @@
             "graphics/znear": 16,
             "graphics/zfar": 32768,
             "graphics/star_blend": false,
-            "graphics/point_sparkles": true,
             "graphics/background": false,
             "graphics/cockpit": false,
             "graphics/planet_detail_level": 48,
-            "graphics/jump_detail": 8
         },
         "Retro": {
             "graphics/fog": false,
@@ -143,11 +133,9 @@
             "graphics/znear": 16,
             "graphics/zfar": 32768,
             "graphics/star_blend": false,
-            "graphics/point_sparkles": true,
             "graphics/background": false,
             "graphics/cockpit": false,
             "graphics/planet_detail_level": 24,
-            "graphics/jump_detail": 8
         }
     },
     "shaders": {


### PR DESCRIPTION
Fix: https://github.com/vegastrike/Assets-Masters/issues/78#issuecomment-3032161249

Both graphics/point_sparkles and graphics/jump_detail are not in the current game_config. 
However, they are also not in the engine.
Therefore, I removed them.

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation _Settings app only._
