### PR TITLE
Update simulation_atom in config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -613,7 +613,7 @@
         "remove_impossible_downgrades": true,
         "roll": 0.0,
         "screen": 0,
-        "simulation_atom": 0.1,
+        "simulation_atom": 0.05,
         "times_to_show_help_screen": 0,
         "trade_interface_tracks_prices": true,
         "trade_interface_tracks_prices_top_rank": 10,


### PR DESCRIPTION
This simulation atom is a safe default for slow machines, and avoids the strange behaviors of 0.1, which introduced some bugs.

Thank you for submitting a pull request and becoming a contributor to Vega Strike: Upon the Coldest Sea.

Please answer the following:

Code Changes:
- [X] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- Please list any related issues
- Fixes https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/1264
- https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/1266

Purpose:
- What is this pull request trying to do?
- - Fixes the first issue, alleviates the second somewhat.
- What release is this for?
- - Git master
- Is there a project or milestone we should apply this to?
- -No
