### PR TITLE
Give Oswald a Robin.stock

### DIFF
--- a/units/ships.json
+++ b/units/ships.json
@@ -3228,7 +3228,7 @@
                         "Max_Cone": "180",
                         "Lock_Cone": "10",
                         "Hold_Volume": "25",
-                        "Upgrades": "{quadshield15;;}{armor06;;}{autotracking;;}{mult_overdrive02;;}{ecm_package03;;}{reactor08;;}{capacitor05;;}",
+                        "Upgrades": "{quadshield05;;}{armor06;;}{autotracking;;}{mult_overdrive02;;}{ecm_package03;;}{reactor08;;}{capacitor05;;}",
                         "Mounts": "{Pugilist;;;light;0.800000;-0.600000;8.000000;;;;;;;;;1;1}{Pugilist;;;light;-0.800000;-0.600000;8.000000;;;;;;;;;1;1}{ParticleBeam;;;light;-0.000000;-0.400000;8.200000;;;;;;;;;1;1}{Swarm;25;7;Special Special-Missile;2.000000;0.800000;-4.000000;;;;;;;;;1;1}{Swarm;25;7;Special Special-Missile;-2.000000;0.800000;-4.000000;;;;;;;;;1;1}{Swarm;25;7;Special Special-Missile;1.000000;-1.400000;-1.000000;;;;;;;;;1;1}{Swarm;25;7;Special Special-Missile;-1.000000;-1.400000;-1.000000;;;;;;;;;1;1}{FriendOrFoe;1;16;Medium-Missile Light-Missile;2.5000000;-1.400000;-2.000000;;;;;;;;;1;1}{FriendOrFoe;1;16;Medium-Missile Light-Missile;-2.5000000;-1.400000;-2.000000;;;;;;;;;1;1}",
                         "armor": "1000.0",
                         "shield": "250.0",


### PR DESCRIPTION
This prevents the shield from suddenly weakening and then Oswald gets angry.

I made a conscious design decision to be lazy (and correct) and not make Oswald fly this super-ship. If you want to kill him on game start, do it and face the consequences.

Code Changes:
- [X] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation _only enough to check Oswald doesn't get angry._

Issues:
- Giving someone a stronger shield or armor through a ships.json entry does not work unless you also enter the relevant stats manually. I knew that and still got it wrong. This is a pervasive issue throughout the game and a design flaw.
