### PR TITLE
gh-actions-*.yml: Add openSUSE Leap 16.0 and Fedora 42

### DIFF
--- a/.github/workflows/gh-actions-pr.yml
+++ b/.github/workflows/gh-actions-pr.yml
@@ -20,7 +20,9 @@ jobs:
         include:
           # only do one Deb file because they're so large
           - FROM:     'debian:bookworm'
+          - FROM:     'opensuse/leap:16.0'
           - FROM:     'opensuse/leap:15.6'
+          - FROM:     'fedora:42'
           - FROM:     'fedora:41'
           - FROM:     'fedora:40'
           - FROM:     'rockylinux_rockylinux:9.5'

--- a/.github/workflows/gh-actions-release.yml
+++ b/.github/workflows/gh-actions-release.yml
@@ -28,7 +28,11 @@ jobs:
           # only build one Deb File b/c they're so large
           - FROM:     'debian:bookworm'
             ARTIFACT_EXT: 'deb'
+          - FROM:     'opensuse/leap:16.0'
+            ARTIFACT_EXT: 'rpm'
           - FROM:     'opensuse/leap:15.6'
+            ARTIFACT_EXT: 'rpm'
+          - FROM:     'fedora:42'
             ARTIFACT_EXT: 'rpm'
           - FROM:     'fedora:41'
             ARTIFACT_EXT: 'rpm'


### PR DESCRIPTION
Code Changes:
- [x] This is a CI / build system change only

Issues:
- N/A

Purpose:
- What is this pull request trying to do? Add openSUSE Leap 16.0 and Fedora 42 builds to our CI and future releases
- What release is this for? 0.10.x and following
- Is there a project or milestone we should apply this to? Probably 0.10.x
