### PR TITLE
Fix Oswald attacking for no reason (1266)

### DIFF
--- a/modules/quests/quest_tutorial.py
+++ b/modules/quests/quest_tutorial.py
@@ -51,6 +51,8 @@ COMPLETE_TUTORIAL4 = 8
 COMPLETE_TUTORIAL5 = 10
 STAGE_DECLINE = 98
 
+oswald_launched = False
+
 # the class that will be executed
 class quest_tutorial (quest.quest):
     # initialize quest variables
@@ -142,7 +144,7 @@ class quest_tutorial (quest.quest):
             vec = Vector.Add(vec,(1000,0,0))
             # launch the tutorial drone.
             #VS.launch(name,type,faction,unittype,ai,nr,nrwaves,pos,squadlogo):
-            self.drone = VS.launch("Oswald","Robin.tutorial","klkk_citizen","unit","default",1,1,vec,'')
+            self.drone = VS.launch("Oswald","Robin.stock","klkk_citizen","unit","default",1,1,vec,'')
             # upgrade drone
             self.drone.upgrade("armor06",0,0,1,0)
             # when launching give the player some text and ask him to decide if he wants to participate
@@ -176,6 +178,9 @@ class quest_tutorial (quest.quest):
             #self.stage = COMPLETE_TUTORIAL3 # debug
             # duration of this part until end of animation
             self.timer = VS.GetGameTime() + 20
+
+            global oswald_launched
+            oswald_launched = True
         return 0
 
     # check if drone has been attacked
@@ -205,6 +210,7 @@ class quest_tutorial (quest.quest):
     # the drone doesn't quite orbit
     # it will approach the player until 1000 meters and then stop
     def orbitMe (self):
+        return 0
         #self.player.SetTarget(self.drone)
         # if the drone is more than 1000m away it will start instructions
         if (self.drone.getDistance(self.player)>=1100):
@@ -936,6 +942,16 @@ class quest_tutorial (quest.quest):
                 self.removeQuest()
                 self.stage += 1 # don't enter this loop anymore
                 return 0
+        # Checks if Oswald is killed after he launches, 
+        # otherwise quest will end before it begins
+        elif (self.drone.isNull() and oswald_launched):
+            self.timer = VS.GetGameTime()+10
+            self.putSaveValue(self.stage)
+            print("Oswald died")
+            print("Tutorial quest terminated")
+            self.removeQuest()
+            self.stage += 1 # don't enter this loop anymore
+            return 0 
         # keep the script alive for execution
         return 1
 


### PR DESCRIPTION
Fix Oswald respawning after dying (1310).

**Bug triage**
- 1266 was due to Oswald using SPEC when getting nearer. Probably due to our tinkering with the auto-pilot/configuration. The script checked the shields weren't down to decide if Oswald is attacked, which caused the bug.
- 1310 was due to the devs not considering the players can kill Oswald. He flew a powerful ship and you really can't defeat him with Llama.begin. Killing him did not remove the quest, which caused the bug.

Fixes https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/1266
Fixes https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/1310

**Code Changes:**
- [x] Have the PR Validation Tests been run? 

Tested:
- Able to complete tutorial without Oswald losing shields and getting angry.
- Killing Oswald removes quest.

Issues:
- Multiple other bugs in the tutorial quest, all minor.

