### PR TITLE
Fix bug 1313

### DIFF
--- a/config.json
+++ b/config.json
@@ -1174,7 +1174,7 @@
         "damage_chance": 0.005,
         "damage_player_chance": 0.5,
         "debris_mass": 0.00001,
-        "debris_time": 500.0,
+        "debris_time": 15.0,
         "default_interdiction": 0.01,
         "default_shield_tightness": 0.0,
         "definite_damage_chance": 0.1,


### PR DESCRIPTION
Cap ship explosion will take 15 seconds and not 500.

Code Changes:
- [ ] Have the PR Validation Tests been run?  **No**

The current game config used the default value of 500 from options.cpp.
However, looking at vegastrike.config shows a value of 15.
It seems this is in seconds, which would explain the long explosions experienced by @evertvorster.

Fixes https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/1313