### PR TITLE
Fix 0.10.0 alpha installers

### DIFF
--- a/.github/workflows/Windows-Release.yml
+++ b/.github/workflows/Windows-Release.yml
@@ -26,8 +26,10 @@ jobs:
         include:
           - os:              windows-2022
             is-release:      1
+            install-nsis:    0
           - os:              windows-2025
             is-release:      1
+            install-nsis:    1
 
     env:
       TAG_NAME: '${{ github.ref_name }}'
@@ -52,6 +54,12 @@ jobs:
 
       - name: Install CMake
         uses: lukka/get-cmake@f5b8fbb4d77cec1acc5a5f9f0df4beffaf5d98d9 #v4.3.4
+
+      - name: Install NSIS
+        if: ${{ matrix.install-nsis }}
+        uses: repolevedavaj/install-nsis@1ab2f7ba2fe9408db612029be0bb3c0088b0d3e9 # v1.2.1
+        with:
+          nsis-version: '3.12'
 
       - name: Build it
         run: script/build.ps1

--- a/.github/workflows/Windows-Release.yml
+++ b/.github/workflows/Windows-Release.yml
@@ -61,10 +61,10 @@ jobs:
         with:
           nsis-version: '3.12'
 
-      - name: Build it
+      - name: Build the code
         run: script/build.ps1
 
-      - name: Package it
+      - name: Package the code
         run: script/package.ps1
 
       - name: Upload the artifacts

--- a/script/package
+++ b/script/package
@@ -99,18 +99,18 @@ function buildPackages()
 
     while [ $hdiutil_success -ne 1 ] && [ $try_count -lt 8 ]; do
         # Create temporary rw image
-        if cpack -V -G DragNDrop
+        if make package
         then
             hdiutil_success=1
             break
         fi
         try_count=$(( $try_count + 1 ))
-        echo "'cpack -V -G DragNDrop' failed (attempt ${try_count}). Retrying..."
+        echo "'make package' failed (attempt ${try_count}). Retrying..."
         sleep 1
     done
 
     if [ $hdiutil_success -ne 1 ]; then
-        echo "FATAL: 'cpack -V -G DragNDrop' FAILED!"
+        echo "FATAL: 'make package' FAILED!"
         exit 1
     fi
 

--- a/script/package
+++ b/script/package
@@ -6,7 +6,7 @@
 # @usage  : script/package
 # @param  : none
 #
-# Copyright (C) 2020-2025 Stephen G. Tuggy and other vsUTCS contributors
+# Copyright (C) 2020-2026 Stephen G. Tuggy and other vsUTCS contributors
 #
 # This file is part of Vega Strike: Upon the Coldest Sea ("vsUTCS").
 #
@@ -23,6 +23,10 @@
 # You should have received a copy of the GNU General Public License
 # along with vsUTCS.  If not, see <https://www.gnu.org/licenses/>.
 
+
+echo "----------------------------"
+echo "--- package | 2026-07-12 ---"
+echo "----------------------------"
 
 ROOT_DIR=$(pwd)
 BUILD_DIR=$ROOT_DIR/build
@@ -79,7 +83,7 @@ function copyTarballs()
 function copyFiles()
 {
     # Ensure the package output directory exists
-    mkdir -p ${PACKAGE_DIR}
+    mkdir -p "${PACKAGE_DIR}"
 
     copyDebFiles
     copyRpmFiles
@@ -95,18 +99,18 @@ function buildPackages()
 
     while [ $hdiutil_success -ne 1 ] && [ $try_count -lt 8 ]; do
         # Create temporary rw image
-        if make package
+        if cpack -V -G DragNDrop
         then
             hdiutil_success=1
             break
         fi
         try_count=$(( $try_count + 1 ))
-        echo "'make package' failed (attempt ${try_count}). Retrying..."
+        echo "'cpack -V -G DragNDrop' failed (attempt ${try_count}). Retrying..."
         sleep 1
     done
 
     if [ $hdiutil_success -ne 1 ]; then
-        echo "FATAL: 'make package' FAILED!"
+        echo "FATAL: 'cpack -V -G DragNDrop' FAILED!"
         exit 1
     fi
 
@@ -132,13 +136,9 @@ function buildPackages()
     fi
 }
 
-echo "----------------------------"
-echo "--- package | 2025-01-22 ---"
-echo "----------------------------"
-
-cd $BUILD_DIR
+cd "$BUILD_DIR" || exit 2
 
 buildPackages
 copyFiles
 
-cd $ROOT_DIR
+cd "$ROOT_DIR" || exit 2


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to Vega Strike: Upon the Coldest Sea.

Please answer the following:

Code Changes:
- [x] This is a CI/build system change only

Issues:
- Fixes https://github.com/vegastrike/Assets-Masters/issues/105

Purpose:
- What is this pull request trying to do? On Windows 2025, install NSIS before trying to create the installer, as NSIS is no longer installed automatically on the GitHub runner image. Make other changes as needed to fix the installer builds.
- What release is this for? 0.10.x and following
- Is there a project or milestone we should apply this to? 0.10.x
