### PR TITLE
Settings app - Make the scroll bar more visible

### DIFF
--- a/python/settings_app/main_app.py
+++ b/python/settings_app/main_app.py
@@ -16,6 +16,19 @@ import tabs.bindings
 import game_config as gc
 import graphics_factory.tooltip as tooltip
 
+from kivy.lang import Builder
+from kivy.metrics import dp
+
+Builder.load_string('''
+#:import dp kivy.metrics.dp
+
+<ScrollView>:
+    bar_width: dp(14)
+    scroll_type: ['bars', 'content']
+    bar_color: 0.6, 0.6, 0.6, 1
+    bar_inactive_color: 0.6, 0.6, 0.6, 1
+    bar_margin: dp(2)
+''')
 
 class MainWindow(BoxLayout):
     def __init__(self, **kwargs):


### PR DESCRIPTION
I was only able to fix the scrollbar issue. Made it always visible and much wider.

Capturing the keyboard is harder because the longest and most used screen is key bindings. There, key clicks are translated to bindings.

closes: https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/1657

Code Changes:
- [ ] Have the PR Validation Tests been run? _No. Tested the settings app only._

Issues:
- Key bindings screen assigns any keyboard click to the a function. Expected behavior - you'd need to **explicitly** select it first.


