### PR TITLE
Sdl2 sdl3 fallback for 0.10.x

### DIFF
--- a/python/settings_app/os_utils.py
+++ b/python/settings_app/os_utils.py
@@ -1,5 +1,5 @@
+import ctypes
 import os
-import screeninfo
 import sys
 
 import app_config as ac
@@ -8,7 +8,6 @@ import app_config as ac
 def change_to_python_settings_app_folder():
     if ac.app_config.assets_folder:
         os.chdir(os.path.join(ac.app_config.assets_folder, "python", "settings_app"))
-    
 
 def append_subfolders_to_system_path():
     subfolders = ['tabs', 'graphics_factory']
@@ -16,12 +15,97 @@ def append_subfolders_to_system_path():
     for folder in subfolders:
         sys.path.append(os.path.join(current_folder, folder))
 
+
+# --- Display detection via SDL3 (ctypes) ---
+#
+# The engine renders through SDL3, so we query the same library the game
+# uses. This is OS-agnostic and, crucially, works correctly under Wayland,
+# unlike the previous `screeninfo` approach (which read X11/xrandr and
+# reported the XWayland-scaled resolution, e.g. 4096x2304 instead of the
+# monitor's native 3840x2160).
+
+SDL_INIT_VIDEO = 0x00000020
+
+class _SDL_DisplayMode(ctypes.Structure):
+    _fields_ = [
+        ("displayID", ctypes.c_uint32),
+        ("format", ctypes.c_uint32),
+        ("w", ctypes.c_int),
+        ("h", ctypes.c_int),
+        ("pixel_density", ctypes.c_float),
+        ("refresh_rate", ctypes.c_float),
+        ("refresh_rate_numerator", ctypes.c_int),
+        ("refresh_rate_denominator", ctypes.c_int),
+        ("internal", ctypes.c_void_p),
+    ]
+
+_sdl = None
+
+def _load_sdl():
+    global _sdl
+    if _sdl is None:
+        _sdl = ctypes.CDLL("libSDL3.so.0")
+    return _sdl
+
+class Monitor:
+    """A lightweight stand-in for a screeninfo.Monitor."""
+    def __init__(self, name, is_primary, width, height):
+        self.name = name
+        self.is_primary = is_primary
+        self.width = width
+        self.height = height
+
+def get_monitors():
+    """Return the connected displays via SDL3 as a list of Monitor objects.
+
+    Resolution is reported in physical pixels (SDL's desktop mode reports
+    logical pixels; multiply by pixel_density to get the native size).
+    """
+    sdl = _load_sdl()
+    sdl.SDL_Init(SDL_INIT_VIDEO)
+
+    sdl.SDL_GetDisplays.argtypes = [ctypes.POINTER(ctypes.c_int)]
+    sdl.SDL_GetDisplays.restype = ctypes.POINTER(ctypes.c_uint32)
+    sdl.SDL_GetDisplayName.argtypes = [ctypes.c_uint32]
+    sdl.SDL_GetDisplayName.restype = ctypes.c_char_p
+    sdl.SDL_GetPrimaryDisplay.argtypes = []
+    sdl.SDL_GetPrimaryDisplay.restype = ctypes.c_uint32
+    sdl.SDL_GetDesktopDisplayMode.argtypes = [ctypes.c_uint32]
+    sdl.SDL_GetDesktopDisplayMode.restype = ctypes.POINTER(_SDL_DisplayMode)
+    sdl.SDL_free.argtypes = [ctypes.c_void_p]
+    sdl.SDL_free.restype = None
+
+    count = ctypes.c_int(0)
+    ids = sdl.SDL_GetDisplays(ctypes.byref(count))
+    primary = sdl.SDL_GetPrimaryDisplay()
+
+    monitors = []
+    try:
+        for i in range(count.value):
+            display_id = ids[i]
+            name = sdl.SDL_GetDisplayName(display_id)
+            mode = sdl.SDL_GetDesktopDisplayMode(display_id)
+            if not mode:
+                continue
+            m = mode.contents
+            monitors.append(Monitor(
+                name=name.decode() if name else str(display_id),
+                is_primary=(display_id == primary),
+                width=round(m.w * m.pixel_density),
+                height=round(m.h * m.pixel_density),
+            ))
+    finally:
+        if ids:
+            sdl.SDL_free(ids)
+        sdl.SDL_Quit()
+
+    return monitors
+
 def number_of_screens():
-    screens = screeninfo.get_monitors()
-    return len(screens)
+    return len(get_monitors())
 
 def resolution_for_screen(index):
-    screens = screeninfo.get_monitors()
+    screens = get_monitors()
     if index >= len(screens):
         return None
     screen = screens[index]

--- a/python/settings_app/os_utils.py
+++ b/python/settings_app/os_utils.py
@@ -1,5 +1,6 @@
-import ctypes
+import json
 import os
+import subprocess
 import sys
 
 import app_config as ac
@@ -16,36 +17,36 @@ def append_subfolders_to_system_path():
         sys.path.append(os.path.join(current_folder, folder))
 
 
-# --- Display detection via SDL3 (ctypes) ---
+# --- Display detection via SDL3 (in a subprocess) ---
 #
 # The engine renders through SDL3, so we query the same library the game
-# uses. This is OS-agnostic and, crucially, works correctly under Wayland,
-# unlike the previous `screeninfo` approach (which read X11/xrandr and
-# reported the XWayland-scaled resolution, e.g. 4096x2304 instead of the
-# monitor's native 3840x2160).
+# uses. This is OS-agnostic and works correctly under Wayland, unlike the
+# previous `screeninfo` approach (which read X11/xrandr and reported the
+# XWayland-scaled resolution, e.g. 4096x2304 instead of the monitor's
+# native 3840x2160).
+#
+# SDL must be queried in a child process: this settings app runs inside
+# Kivy, which uses SDL2 for its own OpenGL context. Initialising SDL3 in
+# the same process tears down that context and segfaults on rendering.
 
-SDL_INIT_VIDEO = 0x00000020
+def get_monitors():
+    """Return the connected displays via SDL3 as a list of Monitor objects.
 
-class _SDL_DisplayMode(ctypes.Structure):
-    _fields_ = [
-        ("displayID", ctypes.c_uint32),
-        ("format", ctypes.c_uint32),
-        ("w", ctypes.c_int),
-        ("h", ctypes.c_int),
-        ("pixel_density", ctypes.c_float),
-        ("refresh_rate", ctypes.c_float),
-        ("refresh_rate_numerator", ctypes.c_int),
-        ("refresh_rate_denominator", ctypes.c_int),
-        ("internal", ctypes.c_void_p),
-    ]
-
-_sdl = None
-
-def _load_sdl():
-    global _sdl
-    if _sdl is None:
-        _sdl = ctypes.CDLL("libSDL3.so.0")
-    return _sdl
+    Resolution is reported in physical pixels (SDL's desktop mode reports
+    logical pixels; multiply by pixel_density to get the native size).
+    """
+    script = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sdl_detect.py")
+    try:
+        result = subprocess.run([sys.executable, script], capture_output=True, timeout=10)
+    except (subprocess.TimeoutExpired, OSError):
+        return []
+    if result.returncode != 0:
+        return []
+    try:
+        data = json.loads(result.stdout.decode())
+    except ValueError:
+        return []
+    return [Monitor(m["name"], m["is_primary"], m["width"], m["height"]) for m in data]
 
 class Monitor:
     """A lightweight stand-in for a screeninfo.Monitor."""
@@ -54,52 +55,6 @@ class Monitor:
         self.is_primary = is_primary
         self.width = width
         self.height = height
-
-def get_monitors():
-    """Return the connected displays via SDL3 as a list of Monitor objects.
-
-    Resolution is reported in physical pixels (SDL's desktop mode reports
-    logical pixels; multiply by pixel_density to get the native size).
-    """
-    sdl = _load_sdl()
-    sdl.SDL_Init(SDL_INIT_VIDEO)
-
-    sdl.SDL_GetDisplays.argtypes = [ctypes.POINTER(ctypes.c_int)]
-    sdl.SDL_GetDisplays.restype = ctypes.POINTER(ctypes.c_uint32)
-    sdl.SDL_GetDisplayName.argtypes = [ctypes.c_uint32]
-    sdl.SDL_GetDisplayName.restype = ctypes.c_char_p
-    sdl.SDL_GetPrimaryDisplay.argtypes = []
-    sdl.SDL_GetPrimaryDisplay.restype = ctypes.c_uint32
-    sdl.SDL_GetDesktopDisplayMode.argtypes = [ctypes.c_uint32]
-    sdl.SDL_GetDesktopDisplayMode.restype = ctypes.POINTER(_SDL_DisplayMode)
-    sdl.SDL_free.argtypes = [ctypes.c_void_p]
-    sdl.SDL_free.restype = None
-
-    count = ctypes.c_int(0)
-    ids = sdl.SDL_GetDisplays(ctypes.byref(count))
-    primary = sdl.SDL_GetPrimaryDisplay()
-
-    monitors = []
-    try:
-        for i in range(count.value):
-            display_id = ids[i]
-            name = sdl.SDL_GetDisplayName(display_id)
-            mode = sdl.SDL_GetDesktopDisplayMode(display_id)
-            if not mode:
-                continue
-            m = mode.contents
-            monitors.append(Monitor(
-                name=name.decode() if name else str(display_id),
-                is_primary=(display_id == primary),
-                width=round(m.w * m.pixel_density),
-                height=round(m.h * m.pixel_density),
-            ))
-    finally:
-        if ids:
-            sdl.SDL_free(ids)
-        sdl.SDL_Quit()
-
-    return monitors
 
 def number_of_screens():
     return len(get_monitors())

--- a/python/settings_app/pyproject.toml
+++ b/python/settings_app/pyproject.toml
@@ -12,7 +12,6 @@ license = "GPL-2.0-only"
 #license-files = ["vega-license.txt"]
 dependencies = [
     "kivy>=2.0.0",
-    "screeninfo>=0.8.1",
 ]
 
 [project.scripts]

--- a/python/settings_app/readme.txt
+++ b/python/settings_app/readme.txt
@@ -25,7 +25,7 @@ Below is a brief description of the files in this folder:
    python3.11 -m venv .venv
    source .venv/bin/activate
    pip3 install --upgrade pip wheel cython setuptools
-   pip install kivy[base] screeninfo
+   pip install kivy[base]
 
     
 

--- a/python/settings_app/sdl_detect.py
+++ b/python/settings_app/sdl_detect.py
@@ -1,0 +1,56 @@
+import ctypes, json, sys
+
+SDL_INIT_VIDEO = 0x00000020
+
+class _SDL_DisplayMode(ctypes.Structure):
+    _fields_ = [
+        ("displayID", ctypes.c_uint32),
+        ("format", ctypes.c_uint32),
+        ("w", ctypes.c_int),
+        ("h", ctypes.c_int),
+        ("pixel_density", ctypes.c_float),
+        ("refresh_rate", ctypes.c_float),
+        ("refresh_rate_numerator", ctypes.c_int),
+        ("refresh_rate_denominator", ctypes.c_int),
+        ("internal", ctypes.c_void_p),
+    ]
+
+def main():
+    sdl = ctypes.CDLL("libSDL3.so.0")
+    sdl.SDL_Init(SDL_INIT_VIDEO)
+    sdl.SDL_GetDisplays.argtypes = [ctypes.POINTER(ctypes.c_int)]
+    sdl.SDL_GetDisplays.restype = ctypes.POINTER(ctypes.c_uint32)
+    sdl.SDL_GetDisplayName.argtypes = [ctypes.c_uint32]
+    sdl.SDL_GetDisplayName.restype = ctypes.c_char_p
+    sdl.SDL_GetPrimaryDisplay.argtypes = []
+    sdl.SDL_GetPrimaryDisplay.restype = ctypes.c_uint32
+    sdl.SDL_GetDesktopDisplayMode.argtypes = [ctypes.c_uint32]
+    sdl.SDL_GetDesktopDisplayMode.restype = ctypes.POINTER(_SDL_DisplayMode)
+    sdl.SDL_free.argtypes = [ctypes.c_void_p]
+    sdl.SDL_free.restype = None
+    count = ctypes.c_int(0)
+    ids = sdl.SDL_GetDisplays(ctypes.byref(count))
+    primary = sdl.SDL_GetPrimaryDisplay()
+    monitors = []
+    try:
+        for i in range(count.value):
+            did = ids[i]
+            name = sdl.SDL_GetDisplayName(did)
+            mode = sdl.SDL_GetDesktopDisplayMode(did)
+            if not mode:
+                continue
+            m = mode.contents
+            monitors.append({
+                "name": name.decode() if name else str(did),
+                "is_primary": did == primary,
+                "width": round(m.w * m.pixel_density),
+                "height": round(m.h * m.pixel_density),
+            })
+    finally:
+        if ids:
+            sdl.SDL_free(ids)
+        sdl.SDL_Quit()
+    json.dump(monitors, sys.stdout)
+
+if __name__ == "__main__":
+    main()

--- a/python/settings_app/sdl_detect.py
+++ b/python/settings_app/sdl_detect.py
@@ -59,8 +59,15 @@ def _load_lib(prefix):
     """Load an SDL library by name prefix (e.g. 'SDL3' or 'SDL2')."""
     libname = ctypes.util.find_library(prefix)
     if libname is None:
-        # Fallbacks for the two SDL major versions.
-        libname = {"SDL3": "libSDL3.so.0", "SDL2": "libSDL2-2.0.so.0"}[prefix]
+        # Platform-aware fallbacks for the two SDL major versions.
+        libname = {
+            ("SDL3", "win32"): "SDL3.dll",
+            ("SDL3", "darwin"): "libSDL3.dylib",
+            ("SDL3", "linux"): "libSDL3.so.0",
+            ("SDL2", "win32"): "SDL2.dll",
+            ("SDL2", "darwin"): "libSDL2-2.0.dylib",
+            ("SDL2", "linux"): "libSDL2-2.0.so.0",
+        }[(prefix, sys.platform)]
     return ctypes.CDLL(libname)
 
 

--- a/python/settings_app/sdl_detect.py
+++ b/python/settings_app/sdl_detect.py
@@ -30,7 +30,8 @@ import sys
 
 SDL_INIT_VIDEO = 0x00000020
 
-class _SDL_DisplayMode(ctypes.Structure):
+
+class _SDL3_DisplayMode(ctypes.Structure):
     _fields_ = [
         ("displayID", ctypes.c_uint32),
         ("format", ctypes.c_uint32),
@@ -43,14 +44,29 @@ class _SDL_DisplayMode(ctypes.Structure):
         ("internal", ctypes.c_void_p),
     ]
 
-def main():
-    # Resolve the SDL3 library name for the current platform (SDL3.dll on
-    # Windows, libSDL3.dylib on macOS, libSDL3.so on Linux) instead of
-    # hardcoding the Linux name, so this works cross-platform.
-    libname = ctypes.util.find_library("SDL3")
+
+class _SDL2_DisplayMode(ctypes.Structure):
+    _fields_ = [
+        ("format", ctypes.c_uint32),
+        ("w", ctypes.c_int),
+        ("h", ctypes.c_int),
+        ("refresh_rate", ctypes.c_int),
+        ("driverdata", ctypes.c_void_p),
+    ]
+
+
+def _load_lib(prefix):
+    """Load an SDL library by name prefix (e.g. 'SDL3' or 'SDL2')."""
+    libname = ctypes.util.find_library(prefix)
     if libname is None:
-        libname = "libSDL3.so.0"  # fallback for Linux when find_library fails
-    sdl = ctypes.CDLL(libname)
+        # Fallbacks for the two SDL major versions.
+        libname = {"SDL3": "libSDL3.so.0", "SDL2": "libSDL2-2.0.so.0"}[prefix]
+    return ctypes.CDLL(libname)
+
+
+def _detect_sdl3():
+    """Enumerate displays via SDL3 (master engine)."""
+    sdl = _load_lib("SDL3")
     sdl.SDL_Init(SDL_INIT_VIDEO)
     sdl.SDL_GetDisplays.argtypes = [ctypes.POINTER(ctypes.c_int)]
     sdl.SDL_GetDisplays.restype = ctypes.POINTER(ctypes.c_uint32)
@@ -59,9 +75,10 @@ def main():
     sdl.SDL_GetPrimaryDisplay.argtypes = []
     sdl.SDL_GetPrimaryDisplay.restype = ctypes.c_uint32
     sdl.SDL_GetDesktopDisplayMode.argtypes = [ctypes.c_uint32]
-    sdl.SDL_GetDesktopDisplayMode.restype = ctypes.POINTER(_SDL_DisplayMode)
+    sdl.SDL_GetDesktopDisplayMode.restype = ctypes.POINTER(_SDL3_DisplayMode)
     sdl.SDL_free.argtypes = [ctypes.c_void_p]
     sdl.SDL_free.restype = None
+
     count = ctypes.c_int(0)
     ids = sdl.SDL_GetDisplays(ctypes.byref(count))
     primary = sdl.SDL_GetPrimaryDisplay()
@@ -84,7 +101,59 @@ def main():
         if ids:
             sdl.SDL_free(ids)
         sdl.SDL_Quit()
+    return monitors
+
+
+def _detect_sdl2():
+    """Enumerate displays via SDL2 (0.10.x engine)."""
+    sdl = _load_lib("SDL2")
+    sdl.SDL_Init(SDL_INIT_VIDEO)
+    sdl.SDL_GetNumVideoDisplays.argtypes = []
+    sdl.SDL_GetNumVideoDisplays.restype = ctypes.c_int
+    sdl.SDL_GetDisplayName.argtypes = [ctypes.c_int]
+    sdl.SDL_GetDisplayName.restype = ctypes.c_char_p
+    sdl.SDL_GetDesktopDisplayMode.argtypes = [ctypes.c_int, ctypes.POINTER(_SDL2_DisplayMode)]
+    sdl.SDL_GetDesktopDisplayMode.restype = ctypes.c_int
+    sdl.SDL_GetDisplayDPI.argtypes = [ctypes.c_int,
+                                      ctypes.POINTER(ctypes.c_float),
+                                      ctypes.POINTER(ctypes.c_float),
+                                      ctypes.POINTER(ctypes.c_float)]
+    sdl.SDL_GetDisplayDPI.restype = ctypes.c_int
+
+    n = sdl.SDL_GetNumVideoDisplays()
+    monitors = []
+    for i in range(n):
+        name = sdl.SDL_GetDisplayName(i)
+        mode = _SDL2_DisplayMode()
+        if sdl.SDL_GetDesktopDisplayMode(i, ctypes.byref(mode)) != 0:
+            continue
+        # SDL2 has no pixel_density; SDL_DisplayMode.w/h are in points. For a
+        # physical resolution, scale by the display DPI relative to 96 DPI.
+        ddpi = ctypes.c_float(0)
+        hdpi = ctypes.c_float(0)
+        vdpi = ctypes.c_float(0)
+        sx = sy = 1.0
+        if sdl.SDL_GetDisplayDPI(i, ctypes.byref(ddpi), ctypes.byref(hdpi), ctypes.byref(vdpi)) == 0 and ddpi.value > 0:
+            sx = hdpi.value / ddpi.value if hdpi.value > 0 else 1.0
+            sy = vdpi.value / ddpi.value if vdpi.value > 0 else 1.0
+        monitors.append({
+            "name": name.decode() if name else str(i),
+            "is_primary": i == 0,  # SDL2 has no primary concept; use the first
+            "width": round(mode.w * sx),
+            "height": round(mode.h * sy),
+        })
+    sdl.SDL_Quit()
+    return monitors
+
+
+def main():
+    # Try SDL3 (master engine) first; fall back to SDL2 (0.10.x engine).
+    try:
+        monitors = _detect_sdl3()
+    except OSError:
+        monitors = _detect_sdl2()
     json.dump(monitors, sys.stdout)
+
 
 if __name__ == "__main__":
     main()

--- a/python/settings_app/sdl_detect.py
+++ b/python/settings_app/sdl_detect.py
@@ -1,4 +1,7 @@
-import ctypes, json, sys
+import ctypes
+import ctypes.util
+import json
+import sys
 
 SDL_INIT_VIDEO = 0x00000020
 
@@ -16,7 +19,13 @@ class _SDL_DisplayMode(ctypes.Structure):
     ]
 
 def main():
-    sdl = ctypes.CDLL("libSDL3.so.0")
+    # Resolve the SDL3 library name for the current platform (SDL3.dll on
+    # Windows, libSDL3.dylib on macOS, libSDL3.so on Linux) instead of
+    # hardcoding the Linux name, so this works cross-platform.
+    libname = ctypes.util.find_library("SDL3")
+    if libname is None:
+        libname = "libSDL3.so.0"  # fallback for Linux when find_library fails
+    sdl = ctypes.CDLL(libname)
     sdl.SDL_Init(SDL_INIT_VIDEO)
     sdl.SDL_GetDisplays.argtypes = [ctypes.POINTER(ctypes.c_int)]
     sdl.SDL_GetDisplays.restype = ctypes.POINTER(ctypes.c_uint32)

--- a/python/settings_app/sdl_detect.py
+++ b/python/settings_app/sdl_detect.py
@@ -1,3 +1,28 @@
+##
+# sdl_detect.py
+#
+# Vega Strike - Space Simulation, Combat and Trading
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
+# Project creator: Daniel Horn
+# Original development team: As listed in the AUTHORS file
+# Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
+#
+# https://github.com/vegastrike/Vega-Strike-Engine-Source
+#
+# This file is part of Vega Strike.
+#
+# Vega Strike is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Vega Strike is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
 import ctypes
 import ctypes.util
 import json

--- a/python/settings_app/tabs/graphics.py
+++ b/python/settings_app/tabs/graphics.py
@@ -2,11 +2,10 @@ from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.label import Label
 from kivy.app import App
 from kivy.properties import StringProperty, ListProperty
-import screeninfo
 import json
 import os
 
-from os_utils import number_of_screens, resolution_for_screen
+from os_utils import Monitor, number_of_screens, resolution_for_screen, get_monitors
 import game_config as gc
 import app_config as ac
 from graphics_factory.label_control_pair import BoolLeafGui, SpinnerLeafGui, SpinnerMultiLeafGui
@@ -23,7 +22,7 @@ class GraphicsTab(BoxLayout):
         self.tab_name = "Graphics"
 
         self.num_screens = number_of_screens()
-        self.screens = screeninfo.get_monitors()
+        self.screens = get_monitors()
         self.screen_resolution = resolution_for_screen(0)
 
         # Make primary screen the first one
@@ -161,8 +160,7 @@ class GraphicsTab(BoxLayout):
 
     # Warning: This method is for testing only
     def add_dummy_screen(self):
-        dummy = screeninfo.Monitor(x=0,y=0,width=1920,height=1080,name='dummy')
-        dummy.is_primary = True
+        dummy = Monitor(name='dummy', is_primary=True, width=1920, height=1080)
         self.screens[0].is_primary = False
         self.screens.append(dummy)
         print(self.screens)


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to Vega Strike: Upon the Coldest Sea.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

This only affects the settings app. 

Issues:
- Please list any related issues
- Settings app mis-detects monitor resolutions on Wayland. 

Purpose:
- What is this pull request trying to do?
* Avoid screeninfo, and use the same SDL that the engine use. 
- What release is this for?
* 0.10.x
- Is there a project or milestone we should apply this to?
