### PR TITLE
Shield maintenance cost 5% -> 1% (restore capacitor-refill behavior)

### DIFF
--- a/config.json
+++ b/config.json
@@ -492,7 +492,7 @@
 
         "shield": {
             "energy_source": "energy",
-            "maintenance_factor": 0.05,
+            "maintenance_factor": 0.01,
             "regeneration_factor": 0.05
         }
 


### PR DESCRIPTION
maintenance_factor 0.05 -> 0.01: shields no longer drain the capacitor at full health; pairs with the energy-limited shield recharge (engine). See vegastrike/Vega-Strike-Engine-Source#1698

Thank you for submitting a pull request and becoming a contributor to Vega Strike: Upon the Coldest Sea.

Please answer the following:

Code Changes:
- [x] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- Please list any related issues
[#
](https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/1698)

Purpose:
- What is this pull request trying to do?
- - Adjust the maintenance value for the shield down while it is fully charged. 

- What release is this for?
- 0.11
- Is there a project or milestone we should apply this to?
