### PR TITLE
Restore shield maintenance_factor 0.01 in engine.json (lost in config…

### DIFF
--- a/engine.json
+++ b/engine.json
@@ -920,7 +920,7 @@
             },
             "shield": {
                 "energy_source": "energy",
-                "maintenance_factor": 0.05,
+                "maintenance_factor": 0.01,
                 "regeneration_factor": 0.05
             }
         },


### PR DESCRIPTION
PR #266 (Aug 8) changed config.json maintenance_factor 0.05 -> 0.01, but the config-split (#270, Aug 9) moved this setting into engine.json base.components. shield and carried over the old 0.05. With the engine now reading engine.json base (post-split), shields drain the capacitor at 5% again. Restore 0.01 so shields don't drain the capacitor at full health (pairs with engine #1698).

Thank you for submitting a pull request and becoming a contributor to Vega Strike: Upon the Coldest Sea.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- Please list any related issues

Purpose:
- What is this pull request trying to do?
- What release is this for?
- Is there a project or milestone we should apply this to?
