### PR TITLE
Fix blank ship stats in base computer: read tuning from engine.json base

### DIFF
--- a/python/base_computer/ship_view.py
+++ b/python/base_computer/ship_view.py
@@ -21,11 +21,27 @@ MOUNTS = 'Mounts'
 non_combat_speed_multiplier = 1
 megajoules_multiplier = 1
 
-with open('config.json', 'r') as file:
-    data = json.load(file)
-    non_combat_speed_multiplier = data['components']['drive']['non_combat_mode_multiplier']
-    megajoules_multiplier = data['constants']['megajoules_multiplier']
-    
+# components/constants live in engine.json under "base" (post config-split).
+# Fall back to config.json for setups that haven't been split yet.
+def _load_engine_tuning():
+    try:
+        with open('engine.json', 'r') as file:
+            base = json.load(file)['base']
+        return (base['components']['drive']['non_combat_mode_multiplier'],
+                base['constants']['megajoules_multiplier'])
+    except (IOError, KeyError, TypeError, ValueError):
+        pass
+    try:
+        with open('config.json', 'r') as file:
+            data = json.load(file)
+        return (data['components']['drive']['non_combat_mode_multiplier'],
+                data['constants']['megajoules_multiplier'])
+    except (IOError, KeyError, TypeError, ValueError):
+        pass
+    return (1, 1)
+
+non_combat_speed_multiplier, megajoules_multiplier = _load_engine_tuning()
+
 # Wasteful
 def get_unit(key):
     with open('units/units.json', 'r') as file:

--- a/python/base_computer/ship_view.py
+++ b/python/base_computer/ship_view.py
@@ -38,7 +38,8 @@ def _load_engine_tuning():
                 data['constants']['megajoules_multiplier'])
     except (IOError, KeyError, TypeError, ValueError):
         pass
-    return (1, 1)
+    # Fall back to the module-level default multipliers (1, 1).
+    return (non_combat_speed_multiplier, megajoules_multiplier)
 
 non_combat_speed_multiplier, megajoules_multiplier = _load_engine_tuning()
 


### PR DESCRIPTION
ship_view.py loaded non_combat_speed_multiplier and megajoules_multiplier from config.json's 'components'/'constants' sections at module import. The config split (#270) moved those sections into engine.json under 'base', so config.json no longer had them and the module raised KeyError('components') at load -- the get_ship_description callback never ran and the ship stats screen was blank.

Read from engine.json base first, fall back to config.json (pre-split setups), then defaults. ship_view.py now imports cleanly and produces ship stats.

Thank you for submitting a pull request and becoming a contributor to Vega Strike: Upon the Coldest Sea.

TL;DR: This fixes a regression introduced by the split config reading. Hopefully the last. 
