### PR TITLE
Restore Oswald as a strong tutorial opponent (Robin.tutorial)

### DIFF
--- a/modules/quests/quest_tutorial.py
+++ b/modules/quests/quest_tutorial.py
@@ -144,7 +144,7 @@ class quest_tutorial (quest.quest):
             vec = Vector.Add(vec,(1000,0,0))
             # launch the tutorial drone.
             #VS.launch(name,type,faction,unittype,ai,nr,nrwaves,pos,squadlogo):
-            self.drone = VS.launch("Oswald","Robin.stock","klkk_citizen","unit","default",1,1,vec,'')
+            self.drone = VS.launch("Oswald","Robin.tutorial","klkk_citizen","unit","default",1,1,vec,'')
             # upgrade drone
             self.drone.upgrade("armor06",0,0,1,0)
             # when launching give the player some text and ask him to decide if he wants to participate
@@ -210,7 +210,6 @@ class quest_tutorial (quest.quest):
     # the drone doesn't quite orbit
     # it will approach the player until 1000 meters and then stop
     def orbitMe (self):
-        return 0
         #self.player.SetTarget(self.drone)
         # if the drone is more than 1000m away it will start instructions
         if (self.drone.getDistance(self.player)>=1100):


### PR DESCRIPTION
Commit efa094b8 (Sep 2025, 'Fix Oswald attacking for no reason' #1266) over-nerfed the tutorial Oswald by switching his ship from the armed Robin.tutorial to the disarmed Robin.stock, and disabled his orbit behavior. Robin.stock has no weapons (empty mounts) and tiny stats (75/facet shields, recharge 4, hull 127) vs Robin.tutorial (Pugilist + ParticleBeam + Swarm + FriendOrFoe, 250/facet shields, recharge 100, hull 500). So Oswald could not fight back at all and his aft shields stripped in one hit.

Restore Oswald to Robin.tutorial (matching the 0.5-era design where he is a strong, difficult opponent) and re-enable his orbit behavior. The original issue 1266 was about aggression timing, not Oswald's loadout; the proper fix belongs in the AI, not by stripping his ship.

**TL;DR:** Oswald IS a highly skilled pilot in a well kitted out ship. Attacking him is a bad idea, and you have very little chance of defending yourself against him in your clapped-out Llama. He teaches you a lesson by stripping your shields and a bit of armor, then goes back to tutorialing. 

This is part of the game, and should not be stripped. (Its also part of game testing, we need a strong enemy to test against)

He is still stupidly enabling SPEC in the middle of the fight, which is a matter for investigation and a different PR. 
