### PR TITLE
base_computer: read config via merged json (fix KeyError after config…

### DIFF
--- a/python/base_computer/config.py
+++ b/python/base_computer/config.py
@@ -1,0 +1,66 @@
+# Merge the split JSON config files the same way the engine does, so
+# base_computer scripts read the effective config instead of a single raw file.
+#
+# The engine (InitPaths) merges, in order, later values overwriting earlier:
+#   1. datadir bindings.json, theme.json, engine.json, config.json  (defaults)
+#   2. homedir bindings.json, theme.json, engine.json, config.json  (user overrides)
+# Within each group config.json loads last so a user-facing setting wins.
+#
+# engine.json holds its engine tuning under a "base" key; unwrap it so
+# constants/components land at the merged root (the C++ engine does not do this
+# itself, which is why those keys were silently missing after the config split).
+
+import json
+import os
+
+CONFIG_FILES = ("bindings.json", "theme.json", "engine.json", "config.json")
+
+
+def _homedir():
+    # ~/.vegastrike — matches the engine's HOMESUBDIR. Portability via getpass.
+    import getpass
+    import platform
+
+    system = platform.system().lower()
+    if system == "windows":
+        import ntpath
+        base = os.path.join(os.environ.get("USERPROFILE", ""), "AppData", "Local")
+        return os.path.join(base, ".vegastrike")
+    if system == "darwin":
+        return os.path.join(os.path.expanduser("~"), ".vegastrike")
+    return os.path.join(os.path.expanduser("~"), ".vegastrike")
+
+
+def _merge(into, src):
+    """Deep-merge src into into (dicts only; later values win, recursively)."""
+    for key, value in src.items():
+        if isinstance(value, dict) and isinstance(into.get(key), dict):
+            _merge(into[key], value)
+        else:
+            into[key] = value
+
+
+def _matching_files(directory):
+    for name in CONFIG_FILES:
+        path = os.path.join(directory, name)
+        if os.path.exists(path):
+            yield name, path
+
+
+def _load_merged(directory):
+    merged = {}
+    for name, path in _matching_files(directory):
+        with open(path, "r") as file:
+            data = json.load(file)
+        # Unwrap engine.json's "base" so its tuning keys live at the root.
+        if name == "engine.json" and isinstance(data, dict) and isinstance(data.get("base"), dict):
+            data = data["base"]
+        _merge(merged, data)
+    return merged
+
+
+def load_merged_config():
+    """Return the effective config (datadir defaults, overridden by homedir)."""
+    merged = _load_merged(os.getcwd())
+    _merge(merged, _load_merged(_homedir()))
+    return merged

--- a/python/base_computer/ship_view.py
+++ b/python/base_computer/ship_view.py
@@ -2,6 +2,8 @@ import locale
 import math
 import json
 
+import config
+
 
 newline = "#n#"
 red = "#c1:.3:.3#"
@@ -21,10 +23,11 @@ MOUNTS = 'Mounts'
 non_combat_speed_multiplier = 1
 megajoules_multiplier = 1
 
-with open('config.json', 'r') as file:
-    data = json.load(file)
-    non_combat_speed_multiplier = data['components']['drive']['non_combat_mode_multiplier']
-    megajoules_multiplier = data['constants']['megajoules_multiplier']
+# Read the effective (merged) config that the engine uses, instead of a raw file.
+_data = config.load_merged_config()
+non_combat_speed_multiplier = _data['components']['drive']['non_combat_mode_multiplier']
+megajoules_multiplier = _data['constants']['megajoules_multiplier']
+vsdm = _data['constants']['kj_per_unit_damage'] / _data['constants']['kilo']
     
 # Wasteful
 def get_unit(key):
@@ -471,7 +474,7 @@ def get_weapons(ship_stats):
             weapon = get_weapon_from_json(mount[0])
             
             if weapon != None:
-                text += get_weapon_details(weapon, 5400, mount[2])
+                text += get_weapon_details(weapon, vsdm, mount[2])
                 continue
             
             # Can't find weapon. It's a missile
@@ -483,7 +486,7 @@ def get_weapons(ship_stats):
             weapon = get_weapon_from_json(ammo_dummy_mounts[0][0])
             
             if weapon != None:
-                text += get_weapon_details(weapon, 5400, mount[2])
+                text += get_weapon_details(weapon, vsdm, mount[2])
             
             
         
@@ -525,7 +528,7 @@ def get_turret_gun(turret_stats, level = 0):
         text += f"{light_grey}{mount[0]} {mount[1]}{end_color}{newline}"
         weapon = get_weapon_from_json(mount[0])
         if weapon != None:
-            text += get_weapon_details(weapon, 5400)
+            text += get_weapon_details(weapon, vsdm)
     return text
 
 

--- a/python/base_computer/upgrade_view.py
+++ b/python/base_computer/upgrade_view.py
@@ -1,6 +1,8 @@
 import json
 import locale
 
+import config
+
 # locale.setlocale(locale.LC_ALL, '')  
 
 def format_number(number) -> str:
@@ -230,9 +232,8 @@ def get_upgrade_info(unit_stats):
 
 
     vsdm = 5.0
-    with open('config.json', 'r') as file:
-        data = json.load(file)
-        vsdm = data['constants']['kj_per_unit_damage'] / data['constants']['kilo']
+    _data = config.load_merged_config()
+    vsdm = _data['constants']['kj_per_unit_damage'] / _data['constants']['kilo']
         
     unit = {}
     with open('units/units.json', 'r') as file:


### PR DESCRIPTION
… split)

The 2026-08-09 config split moved constants/components out of config.json into engine.json -> base. ship_view.py and upgrade_view.py still read config.json directly, so data['constants'] / data['components'] now raise KeyError and base screens break.

Add python/base_computer/config.py which merges the split config files the same way the engine (InitPaths) does: datadir default files then homedir overrides, config.json last in each group, engine.json's 'base' unwrapped so constants/components land at the merged root. The C++ engine's load_config does not unwrap 'base', which is why these keys were silently missing.

ship_view.py: query non_combat_mode_multiplier and megajoules_multiplier from the merged config; compute vsdm (kj_per_unit_damage/kilo) once and pass it to get_weapon_details, removing three hardcoded 5400 literals (a pre-existing display inconsistency vs upgrade_view's divide-by-kilo).

upgrade_view.py: query kj_per_unit_damage and kilo from the merged config.

Thank you for submitting a pull request and becoming a contributor to Vega Strike: Upon the Coldest Sea.

Please answer the following:

Code Changes:
- [x] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- Please list any related issues

Purpose:
- What is this pull request trying to do?
- - fix more fallout from the split config files.
- What release is this for?
- -0.11
- Is there a project or milestone we should apply this to?
- -0.11
