### PR TITLE
Add macOS 26 support to 0.10.x

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -19,11 +19,12 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          # x86-64
-          - macos-15-intel
-          # M1 processor
-          #- macos-14
-          #- macos-15
+          # x86_64
+          - macOS-15-intel
+          - macOS-26-intel
+          # Apple Silicon
+          #- macOS-15
+          #- macOS-26
 
     steps:
       - name: Check out repository

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -25,11 +25,12 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          # x86-64
-          - macos-15-intel
-          # M1 processor
-          #- macos-14
-          #- macos-15
+          # x86_64
+          - macOS-15-intel
+          - macOS-26-intel
+          # Apple Silicon
+          #- macOS-15
+          #- macOS-26
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to Vega Strike: Upon the Coldest Sea.

Please answer the following:

Code Changes:
- [x] This is a CI/build system/installer change only

Issues Addressed:
- Implements https://github.com/vegastrike/Assets-Masters/issues/106 for 0.10.x

Known Issues Remaining:
- Nothing new that I'm aware of

Purpose:
- What is this pull request trying to do? Add macOS 26 support to 0.10.x.
- What release is this for? 0.10.x
- Is there a project or milestone we should apply this to? 0.10.x
