### PR TITLE
Fixes error - 0:75(9): error: no matching function for call 

### DIFF
--- a/programs/fireglass.fp
+++ b/programs/fireglass.fp
@@ -72,7 +72,7 @@ float GLOSS_power( in float mat_gloss_sa, in float light_solid_angle ) //const
 {
   // shininess = ( 0.5 * pi / SolidAngle ) - 0.810660172
   const float MAGIC_TERM = 0.810660172;
-  return max(0, ( HALF_PI / (mat_gloss_sa + light_solid_angle + 0.0005) ) - MAGIC_TERM);
+  return max(0.0, ( HALF_PI / (mat_gloss_sa + light_solid_angle + 0.0005) ) - MAGIC_TERM);
 }
 //public:
 vec3 GLOSS_env_reflection( in vec4 mat_gloss, in vec3 direction ) //const


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to Vega Strike: Upon the Coldest Sea.

Please answer the following:

Code Changes:
- [X] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

This fixes the following console error:
```
0:75(9): error: no matching function for call to `max(int, float)'; candidates are:
0:75(9): error:    float max(float, float)
0:75(9): error:    vec2 max(vec2, float)
0:75(9): error:    vec3 max(vec3, float)
0:75(9): error:    vec4 max(vec4, float)
0:75(9): error:    vec2 max(vec2, vec2)
0:75(9): error:    vec3 max(vec3, vec3)
0:75(9): error:    vec4 max(vec4, vec4)
0:75(9): error:    int max(int, int)
0:75(9): error:    ivec2 max(ivec2, int)
0:75(9): error:    ivec3 max(ivec3, int)
0:75(9): error:    ivec4 max(ivec4, int)
0:75(9): error:    ivec2 max(ivec2, ivec2)
0:75(9): error:    ivec3 max(ivec3, ivec3)
0:75(9): error:    ivec4 max(ivec4, ivec4)
0:75(2): error: `return' with wrong type error, in function `GLOSS_power' returning float
0:197(14): warning: `mtl_gloss' used uninitialized
Fragment Program Error: Failed to compile fireglass
Compilation of technique fireglass failed... trying default
Cause: Error compiling program vp:"fireglass" fp:"fireglass"
```
