### PR TITLE
Fixes error - 0:75(9): error: no matching function for call to `max(i…

### DIFF
--- a/programs/fireglass.fp
+++ b/programs/fireglass.fp
@@ -72,7 +72,7 @@ float GLOSS_power( in float mat_gloss_sa, in float light_solid_angle ) //const
 {
   // shininess = ( 0.5 * pi / SolidAngle ) - 0.810660172
   const float MAGIC_TERM = 0.810660172;
-  return max(0, ( HALF_PI / (mat_gloss_sa + light_solid_angle + 0.0005) ) - MAGIC_TERM);
+  return max(0.0, ( HALF_PI / (mat_gloss_sa + light_solid_angle + 0.0005) ) - MAGIC_TERM);
 }
 //public:
 vec3 GLOSS_env_reflection( in vec4 mat_gloss, in vec3 direction ) //const


### PR DESCRIPTION
…nt, float)'

Thank you for submitting a pull request and becoming a contributor to Vega Strike: Upon the Coldest Sea.

Please answer the following:

Code Changes:
- [X] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

0.10.x port of #284 
