### PR TITLE
main menu: widen the save-game list text box to ~66% of the screen

### DIFF
--- a/bases/computer_lib.py
+++ b/bases/computer_lib.py
@@ -143,7 +143,7 @@ class QuineComputer:
         # this doesn't change while docked, so only call it once
         self.str_start = get_location_text(current_base)
 
-        screen_loc = GUI.GUIRect(80,90,350,380,"pixel",(800,600))
+        screen_loc = GUI.GUIRect(80,90,700,380,"pixel",(800,600))
         screen_color = GUI.GUIColor(20/255.0, 22/255.0 ,10/255.0)               # first I tried rgb(56 60 24) and rgb(40 44 20); both were too light
         screen_bgcolor = GUI.GUIColor.clear()
         screen_bgcolor_nc = GUI.GUIColor(0.44,0.47,0.17)

--- a/bases/computer_lib.py
+++ b/bases/computer_lib.py
@@ -143,7 +143,7 @@ class QuineComputer:
         # this doesn't change while docked, so only call it once
         self.str_start = get_location_text(current_base)
 
-        screen_loc = GUI.GUIRect(80,90,700,380,"pixel",(800,600))
+        screen_loc = GUI.GUIRect(80,90,528,380,"pixel",(800,600))
         screen_color = GUI.GUIColor(20/255.0, 22/255.0 ,10/255.0)               # first I tried rgb(56 60 24) and rgb(40 44 20); both were too light
         screen_bgcolor = GUI.GUIColor.clear()
         screen_bgcolor_nc = GUI.GUIColor(0.44,0.47,0.17)


### PR DESCRIPTION
The load/save picker's per-row text box spanned only ~44% of the screen, so long auto-generated save names (single underscore tokens, e.g. 'Serenity_Collecting_Cargo') exceeded the box and TextPlane hard-wrapped them onto a second line, overlapping the next row.

Double the shared screen_loc width (350 -> 700 of the 800-wide design = 88%), giving save names ~2x the room before wrapping. Affects both the txt_screen (location text) and picker_screen (save list), which share screen_loc.

Thank you for submitting a pull request and becoming a contributor to Vega Strike: Upon the Coldest Sea.

Please answer the following:

Code Changes:
- [x] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- Please list any related issues

Purpose:
- What is this pull request trying to do?
- - Stops long saved game names from wrapping. 
- What release is this for?
- - 0.11
- Is there a project or milestone we should apply this to?
- - 0.11
